### PR TITLE
Allows a multitool to force-broadcast vents and scrubbers.

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -691,6 +691,7 @@
 					return 1
 
 				if( "power",
+					"direction",
 					"adjust_external_pressure",
 					"checks",
 					"o2_scrub",

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -399,6 +399,10 @@
 			"You hear welding.")
 		return 1
 
+	if(isMultitool(W))
+		broadcast_status()
+		to_chat(user, "<span class='notice'>A [name == "Air Vent" ? "red" : "green"] light appears on \the [src] as it broadcasts atmospheric data.</span>")
+		flick("broadcast", src)
 	else
 		..()
 

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -324,6 +324,11 @@
 			"You hear welding.")
 		return 1
 
+	if(isMultitool(W))
+		broadcast_status()
+		to_chat(user, "<span class='notice'>A [name == "Air Vent" ? "red" : "green"] light appears on \the [src] as it broadcasts atmospheric data.</span>")
+		flick("broadcast", src)
+
 	return ..()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/examine(mob/user)

--- a/nano/templates/air_alarm.tmpl
+++ b/nano/templates/air_alarm.tmpl
@@ -128,7 +128,8 @@ Used In File(s): \code\game\machinery\alarm.dm
 					Operation Mode:
 				</div>
 				<div class="itemContent">
-					{{:value.direction == "siphon" ? 'Siphoning' : 'Pressurizing'}}
+					{{:helper.link('Siphon', null, { 'id_tag' : value.id_tag, 'command' : 'direction', 'val' : value.direction^0}, null, value.direction == "siphon" ? 'selected' : null)}}
+					{{:helper.link('Pressurize', null, { 'id_tag' : value.id_tag, 'command' : 'direction', 'val' : value.direction^1}, null, value.direction == "release" ? 'selected' : null)}}
 				</div>
 			</div>
 			<div class="item">


### PR DESCRIPTION
Allows you to toggle a vent from pressurize to syphon from an air alarm as well.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

  