### PR TITLE
Adds in specific first-aid crates to Supply Management

### DIFF
--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -29,6 +29,36 @@
 	cost = 15
 	containername = "\improper O- blood crate"
 
+/decl/hierarchy/supply_pack/medical/firstaid
+	name = "Regular first-aid kits"
+	contains = list(/obj/item/weapon/storage/firstaid/regular = 4)
+	cost = 15
+	containername = "\improper First-aid crate"
+
+/decl/hierarchy/supply_pack/medical/firstaidfire
+	name = "Fire first-aid kits"
+	contains = list(/obj/item/weapon/storage/firstaid/fire = 3)
+	cost = 20
+	containername = "\improper Fire first-aid crate"
+
+/decl/hierarchy/supply_pack/medical/firstaidtoxin
+	name = "Toxin first-aid kits"
+	contains = list(/obj/item/weapon/storage/firstaid/toxin = 3)
+	cost = 20
+	containername = "\improper Toxin first-aid crate"
+
+/decl/hierarchy/supply_pack/medical/firstaido2
+	name = "O2 first-aid kits"
+	contains = list(/obj/item/weapon/storage/firstaid/o2 = 3)
+	cost = 20
+	containername = "\improper O2 first-aid crate"
+
+/decl/hierarchy/supply_pack/medical/firstaidadv
+	name = "Advanced first-aid kits"
+	contains = list(/obj/item/weapon/storage/firstaid/adv = 3)
+	cost = 25
+	containername = "\improper Advanced first-aid crate"
+
 /decl/hierarchy/supply_pack/medical/bodybag
 	name = "Body bag crate"
 	contains = list(/obj/item/weapon/storage/box/bodybags = 3)


### PR DESCRIPTION
Adds in specific first-aid supply crates so you don't need to order the Medical Crate for 5 other items you won't use, the crates are more expensive than the regular Medical Crates despite giving less total items. That is an intentional drawback, blame how Central Command's Supply department organizes things.
