### PR TITLE
[Fix] Stops lockers from spawning more items each time the server enters a new round.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -44,8 +44,8 @@
 	icon_state = "syndicate1"
 	icon_closed = "syndicate1"
 	icon_opened = "syndicate1open"
-//
-/obj/structure/closet/gimmick/tacticool/WillContain()
+/*
+ * /obj/structure/closet/gimmick/tacticool/WillContain()
 	return list(
 		/obj/item/clothing/glasses/eyepatch,
 		/obj/item/clothing/glasses/sunglasses,
@@ -55,7 +55,7 @@
 		/obj/item/clothing/shoes/swat = 2,
 		/obj/item/clothing/suit/space/void/swat = 2,
 		/obj/item/clothing/under/syndicate/tacticool = 2)
-//
+*\
 /obj/structure/closet/thunderdome
 	name = "\improper Thunderdome closet"
 	desc = "Everything you need!"

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -44,6 +44,7 @@
 	icon_state = "syndicate1"
 	icon_closed = "syndicate1"
 	icon_opened = "syndicate1open"
+	
 /*
  * /obj/structure/closet/gimmick/tacticool/WillContain()
 	return list(
@@ -55,7 +56,8 @@
 		/obj/item/clothing/shoes/swat = 2,
 		/obj/item/clothing/suit/space/void/swat = 2,
 		/obj/item/clothing/under/syndicate/tacticool = 2)
-*\
+ */
+ 
 /obj/structure/closet/thunderdome
 	name = "\improper Thunderdome closet"
 	desc = "Everything you need!"

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -44,7 +44,7 @@
 	icon_state = "syndicate1"
 	icon_closed = "syndicate1"
 	icon_opened = "syndicate1open"
-/*
+//
 /obj/structure/closet/gimmick/tacticool/WillContain()
 	return list(
 		/obj/item/clothing/glasses/eyepatch,
@@ -55,7 +55,7 @@
 		/obj/item/clothing/shoes/swat = 2,
 		/obj/item/clothing/suit/space/void/swat = 2,
 		/obj/item/clothing/under/syndicate/tacticool = 2)
-*\
+//
 /obj/structure/closet/thunderdome
 	name = "\improper Thunderdome closet"
 	desc = "Everything you need!"

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -46,7 +46,7 @@
 	icon_opened = "syndicate1open"
 	
 /*
- * /obj/structure/closet/gimmick/tacticool/WillContain()
+/obj/structure/closet/gimmick/tacticool/WillContain()
 	return list(
 		/obj/item/clothing/glasses/eyepatch,
 		/obj/item/clothing/glasses/sunglasses,

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -44,7 +44,7 @@
 	icon_state = "syndicate1"
 	icon_closed = "syndicate1"
 	icon_opened = "syndicate1open"
-
+/*
 /obj/structure/closet/gimmick/tacticool/WillContain()
 	return list(
 		/obj/item/clothing/glasses/eyepatch,
@@ -55,7 +55,7 @@
 		/obj/item/clothing/shoes/swat = 2,
 		/obj/item/clothing/suit/space/void/swat = 2,
 		/obj/item/clothing/under/syndicate/tacticool = 2)
-
+*\
 /obj/structure/closet/thunderdome
 	name = "\improper Thunderdome closet"
 	desc = "Everything you need!"

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -13,7 +13,7 @@
 	desc = "It's a storage unit for formal clothing."
 	icon_state = "black"
 	icon_closed = "black"
-
+/*
 /obj/structure/closet/gmcloset/WillContain()
 	return list(
 		/obj/item/clothing/head/that = 2,
@@ -28,6 +28,7 @@
 		/obj/item/clothing/accessory/wcoat = 2,
 		/obj/item/clothing/shoes/black = 2
 	)
+*/
 
 /*
  * Chef
@@ -37,7 +38,7 @@
 	desc = "It's a storage unit for foodservice garments."
 	icon_state = "black"
 	icon_closed = "black"
-
+/*
 /obj/structure/closet/chefcloset/WillContain()
 	return list(
 		/obj/item/clothing/under/sundress,
@@ -47,6 +48,7 @@
 		/obj/item/clothing/under/rank/chef,
 		/obj/item/clothing/head/chefhat
 	)
+*/
 
 /*
  * Janitor
@@ -57,6 +59,7 @@
 	icon_state = "mixed"
 	icon_closed = "mixed"
 
+/*
 /obj/structure/closet/jcloset/WillContain()
 	return list(
 		/obj/item/clothing/under/rank/janitor,
@@ -71,6 +74,7 @@
 		/obj/item/weapon/storage/bag/trash,
 		/obj/item/clothing/shoes/galoshes,
 		/obj/item/weapon/soap/nanotrasen)
+*/
 
 /*
  * Lawyer
@@ -80,7 +84,7 @@
 	desc = "It's a storage unit for courtroom apparel and items."
 	icon_state = "blue"
 	icon_closed = "blue"
-
+/*
 /obj/structure/closet/lawcloset/WillContain()
 	return list(
 		/obj/item/clothing/under/lawyer/female,
@@ -93,3 +97,4 @@
 		/obj/item/clothing/shoes/brown,
 		/obj/item/clothing/shoes/black
 	)
+*/

--- a/code/game/objects/structures/crates_lockers/closets/l3closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/l3closet.dm
@@ -9,7 +9,7 @@
 	icon_state = "bio_general"
 	icon_closed = "bio_general"
 	icon_opened = "bio_generalopen"
-
+/*
 /obj/structure/closet/l3closet/general/WillContain()
 	return list(
 		/obj/item/clothing/suit/bio_suit/general,
@@ -25,13 +25,13 @@
 		/obj/item/clothing/suit/bio_suit/general = 5,
 		/obj/item/weapon/tank/emergency/oxygen/engi = 5
 	))
-
+*/
 
 /obj/structure/closet/l3closet/virology
 	icon_state = "bio_virology"
 	icon_closed = "bio_virology"
 	icon_opened = "bio_virologyopen"
-
+/*
 /obj/structure/closet/l3closet/virology/WillContain()
 	return list(
 		/obj/item/clothing/suit/bio_suit/virology,
@@ -39,13 +39,13 @@
 		/obj/item/clothing/mask/gas,
 		/obj/item/weapon/tank/oxygen
 	)
-
+*/
 
 /obj/structure/closet/l3closet/security
 	icon_state = "bio_security"
 	icon_closed = "bio_security"
 	icon_opened = "bio_securityopen"
-
+/*
 /obj/structure/closet/l3closet/security/WillContain()
 	return list(
 		/obj/item/clothing/suit/bio_suit/security,
@@ -53,12 +53,12 @@
 		/obj/item/clothing/mask/gas/half,
 		/obj/item/weapon/tank/emergency/oxygen/engi
 	)
-
+*/
 /obj/structure/closet/l3closet/janitor
 	icon_state = "bio_janitor"
 	icon_closed = "bio_janitor"
 	icon_opened = "bio_janitoropen"
-
+/*
 /obj/structure/closet/l3closet/janitor/WillContain()
 	return list(
 		/obj/item/clothing/suit/bio_suit/janitor,
@@ -66,12 +66,12 @@
 		/obj/item/clothing/mask/gas/half,
 		/obj/item/weapon/tank/emergency/oxygen/engi
 	)
-
+*/
 /obj/structure/closet/l3closet/scientist
 	icon_state = "bio_scientist"
 	icon_closed = "bio_scientist"
 	icon_opened = "bio_scientistopen"
-
+/*
 /obj/structure/closet/l3closet/scientist/WillContain()
 	return list(
 		/obj/item/clothing/suit/bio_suit/scientist,
@@ -87,12 +87,12 @@
 		/obj/item/clothing/mask/gas = 5,
 		/obj/item/weapon/tank/emergency/oxygen/double = 5,
 	))
-
+*/
 /obj/structure/closet/l3closet/command
 	icon_state = "bio_command"
 	icon_closed = "bio_command"
 	icon_opened = "bio_commandopen"
-
+/*
 /obj/structure/closet/l3closet/command/WillContain()
 	return list(
 		/obj/item/clothing/suit/bio_suit/cmo,
@@ -100,3 +100,4 @@
 		/obj/item/clothing/mask/gas/half,
 		/obj/item/weapon/tank/emergency/oxygen/engi
 	)
+*/

--- a/code/game/objects/structures/crates_lockers/closets/malfunction.dm
+++ b/code/game/objects/structures/crates_lockers/closets/malfunction.dm
@@ -3,7 +3,7 @@
 	icon_state = "syndicate"
 	icon_closed = "syndicate"
 	icon_opened = "syndicateopen"
-
+/*
 /obj/structure/closet/malf/suits/WillContain()
 	return list(
 		/obj/item/weapon/tank/jetpack/void,
@@ -13,3 +13,4 @@
 		/obj/item/weapon/crowbar,
 		/obj/item/weapon/cell,
 		/obj/item/device/multitool)
+*/

--- a/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
@@ -9,4 +9,4 @@
 	icon_off = "cabinetdetective_broken"
 
 /obj/structure/closet/secure_closet/bar/WillContain()
-	return list(/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer = 10)
+	return list(/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer = 4)

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -7,7 +7,7 @@
 	icon_opened = "securecargoopen"
 	icon_broken = "securecargobroken"
 	icon_off = "securecargooff"
-
+/*
 /obj/structure/closet/secure_closet/cargotech/WillContain()
 	return list(
 		new/datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack = 75,  /obj/item/weapon/storage/backpack/satchel/grey = 25)),
@@ -18,7 +18,7 @@
 		/obj/item/clothing/gloves/thick,
 		/obj/item/clothing/head/soft
 	)
-
+*/
 /obj/structure/closet/secure_closet/quartermaster
 	name = "quartermaster's locker"
 	req_access = list(access_qm)
@@ -28,7 +28,7 @@
 	icon_opened = "secureqmopen"
 	icon_broken = "secureqmbroken"
 	icon_off = "secureqmoff"
-
+/*
 /obj/structure/closet/secure_closet/quartermaster/WillContain()
 	return list(
 		new/datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack = 75,  /obj/item/weapon/storage/backpack/satchel/grey = 25)),
@@ -43,3 +43,4 @@
 		/obj/item/clothing/glasses/meson,
 		/obj/item/clothing/head/soft
 	)
+*/

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -7,7 +7,7 @@
 	icon_opened = "secureceopen"
 	icon_broken = "securecebroken"
 	icon_off = "secureceoff"
-
+/*
 /obj/structure/closet/secure_closet/engineering_chief/WillContain()
 	return list(
 		new/datum/atom_creator/weighted(list(/obj/item/clothing/accessory/storage/brown_vest = 70, /obj/item/clothing/accessory/storage/webbing = 30)),
@@ -29,6 +29,7 @@
 		/obj/item/taperoll/engineering,
 		/obj/item/weapon/crowbar/brace_jack
 	)
+*/
 
 /obj/structure/closet/secure_closet/engineering_electrical
 	name = "electrical supplies"
@@ -40,6 +41,7 @@
 	icon_broken = "secureengelecbroken"
 	icon_off = "secureengelecoff"
 
+/*
 /obj/structure/closet/secure_closet/engineering_electrical/WillContain()
 	return list(
 		/obj/item/clothing/gloves/nabber = 2,
@@ -48,6 +50,7 @@
 		/obj/item/weapon/module/power_control = 3,
 		/obj/item/device/multitool = 3
 	)
+*/
 
 /obj/structure/closet/secure_closet/engineering_welding
 	name = "welding supplies"
@@ -58,7 +61,7 @@
 	icon_opened = "toolclosetopen"
 	icon_broken = "secureengweldbroken"
 	icon_off = "secureengweldoff"
-
+/*
 /obj/structure/closet/secure_closet/engineering_welding/WillContain()
 	return list(
 		/obj/item/clothing/head/welding = 3,
@@ -67,6 +70,7 @@
 		/obj/item/clothing/glasses/welding = 3,
 		/obj/item/weapon/welder_tank = 6
 	)
+*/
 
 /obj/structure/closet/secure_closet/engineering_personal
 	name = "engineer's locker"
@@ -77,7 +81,7 @@
 	icon_opened = "secureengopen"
 	icon_broken = "secureengbroken"
 	icon_off = "secureengoff"
-
+/*
 /obj/structure/closet/secure_closet/engineering_personal/WillContain()
 	return list(
 		new/datum/atom_creator/weighted(list(/obj/item/clothing/accessory/storage/brown_vest = 70, /obj/item/clothing/accessory/storage/webbing = 30)),
@@ -91,6 +95,7 @@
 		/obj/item/weapon/cartridge/engineering,
 		/obj/item/taperoll/engineering
 	)
+*/
 
 /obj/structure/closet/secure_closet/atmos_personal
 	name = "technician's locker"
@@ -101,7 +106,7 @@
 	icon_opened = "secureatmopen"
 	icon_broken = "secureatmbroken"
 	icon_off = "secureatmoff"
-
+/*
 /obj/structure/closet/secure_closet/atmos_personal/WillContain()
 	return list(
 		new/datum/atom_creator/weighted(list(/obj/item/clothing/accessory/storage/brown_vest = 70, /obj/item/clothing/accessory/storage/webbing = 30)),
@@ -116,3 +121,4 @@
 		/obj/item/weapon/cartridge/atmos,
 		/obj/item/taperoll/atmos
 	)
+*/

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -1,13 +1,13 @@
 /obj/structure/closet/secure_closet/freezer/kitchen
 	name = "kitchen cabinet"
 	req_access = list(access_kitchen)
-
+/*
 /obj/structure/closet/secure_closet/freezer/kitchen/WillContain()
 	return list(
 		/obj/item/weapon/reagent_containers/food/condiment/flour = 7,
 		/obj/item/weapon/reagent_containers/food/condiment/sugar = 2
 	)
-
+*/
 /obj/structure/closet/secure_closet/freezer/kitchen/mining
 	req_access = list()
 
@@ -19,12 +19,12 @@
 	icon_opened = "fridgeopen"
 	icon_broken = "fridgebroken"
 	icon_off = "fridgebroken"
-
+/*
 /obj/structure/closet/secure_closet/freezer/meat/WillContain()
 	return list(
 		/obj/item/weapon/reagent_containers/food/snacks/meat/monkey = 10
 	)
-
+*/
 /obj/structure/closet/secure_closet/freezer/fridge
 	name = "refrigerator"
 	icon_state = "fridge1"
@@ -33,14 +33,14 @@
 	icon_opened = "fridgeopen"
 	icon_broken = "fridgebroken"
 	icon_off = "fridgebroken"
-
+/*
 /obj/structure/closet/secure_closet/freezer/fridge/WillContain()
 	return list(
 		/obj/item/weapon/reagent_containers/food/drinks/milk = 6,
 		/obj/item/weapon/reagent_containers/food/drinks/soymilk = 4,
 		/obj/item/weapon/storage/fancy/egg_box = 4
 	)
-
+*/
 /obj/structure/closet/secure_closet/freezer/money
 	name = "secure locker"
 	icon_state = "fridge1"

--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -7,7 +7,7 @@
 	icon_opened = "hydrosecureopen"
 	icon_broken = "hydrosecurebroken"
 	icon_off = "hydrosecureoff"
-
+/*
 /obj/structure/closet/secure_closet/hydroponics/WillContain()
 	return list(
 		new /datum/atom_creator/weighted(list(/obj/item/clothing/suit/apron, /obj/item/clothing/suit/apron/overalls)),
@@ -21,3 +21,4 @@
 		/obj/item/weapon/wirecutters/clippers,
 		/obj/item/weapon/reagent_containers/spray/plantbgone,
 	)
+*/

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -21,7 +21,7 @@
 	icon_broken = "medicalbroken"
 	icon_off = "medicaloff"
 	req_access = list(access_medical_equip)
-
+/*
 /obj/structure/closet/secure_closet/medical1/WillContain()
 	return list(
 		/obj/item/weapon/storage/box/autoinjectors,
@@ -34,6 +34,7 @@
 		/obj/item/weapon/storage/box/masks,
 		/obj/item/weapon/storage/box/gloves
 	)
+*/
 
 /obj/structure/closet/secure_closet/medical2
 	name = "anesthetics closet"
@@ -45,12 +46,13 @@
 	icon_broken = "medicalbroken"
 	icon_off = "medicaloff"
 	req_access = list(access_surgery)
-
+/*
 /obj/structure/closet/secure_closet/medical2/WillContain()
 	return list(
 		/obj/item/weapon/tank/anesthetic = 3,
 		/obj/item/clothing/mask/breath/medical = 3
 	)
+*/
 
 /obj/structure/closet/secure_closet/medical3
 	name = "medical doctor's locker"
@@ -61,7 +63,7 @@
 	icon_opened = "securemedopen"
 	icon_broken = "securemedbroken"
 	icon_off = "securemedoff"
-
+/*
 /obj/structure/closet/secure_closet/medical3/WillContain()
 	return list(
 		new/datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/medic, /obj/item/weapon/storage/backpack/satchel_med)),
@@ -80,6 +82,7 @@
 		RANDOM_SCRUBS,
 		RANDOM_SCRUBS
 	)
+*/
 
 /obj/structure/closet/secure_closet/paramedic
 	name = "paramedic locker"
@@ -91,7 +94,7 @@
 	icon_broken = "medicalbroken"
 	icon_off = "medicaloff"
 	req_access = list(access_medical_equip)
-
+/*
 /obj/structure/closet/secure_closet/paramedic/WillContain()
 	return list(
 	    /obj/item/weapon/storage/box/autoinjectors,
@@ -115,6 +118,7 @@
 	    /obj/item/weapon/storage/box/freezer,
 	    /obj/item/clothing/accessory/storage/white_vest,
 	)
+*/
 
 /obj/structure/closet/secure_closet/CMO
 	name = "chief medical officer's locker"
@@ -125,7 +129,7 @@
 	icon_opened = "cmosecureopen"
 	icon_broken = "cmosecurebroken"
 	icon_off = "cmosecureoff"
-
+/*
 /obj/structure/closet/secure_closet/CMO/WillContain()
 	return list(
 		new/datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/medic, /obj/item/weapon/storage/backpack/satchel_med)),
@@ -144,6 +148,7 @@
 		/obj/item/weapon/reagent_containers/hypospray/vial,
 		RANDOM_SCRUBS
 	)
+*/
 
 /obj/structure/closet/secure_closet/chemical
 	name = "chemical closet"
@@ -155,13 +160,14 @@
 	icon_broken = "medicalbroken"
 	icon_off = "medicaloff"
 	req_access = list(access_chemistry)
-
+/*
 /obj/structure/closet/secure_closet/chemical/WillContain()
 	return list(
 		/obj/item/weapon/storage/box/pillbottles = 2,
 		/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,
 		/obj/random/medical = 12
 	)
+*/
 
 /obj/structure/closet/secure_closet/medical_wall
 	name = "first aid closet"
@@ -187,7 +193,7 @@
 	icon_opened = "chaplainsecureopen"
 	icon_broken = "chaplainsecurebroken"
 	icon_off = "chaplainsecureoff"
-
+/*
 /obj/structure/closet/secure_closet/counselor/WillContain()
 	return list(
 		/obj/item/clothing/under/rank/psych,
@@ -211,6 +217,7 @@
 		/obj/item/device/camera,
 		/obj/item/toy/therapy_blue,
 	)
+*/
 
 /obj/structure/closet/secure_closet/virology
 	name = "virologist's locker"
@@ -221,7 +228,7 @@
 	icon_broken = "securevirobroken"
 	icon_off = "securevirooff"
 	req_access = list(access_virology)
-
+/*
 /obj/structure/closet/secure_closet/virology/WillContain()
 	return list(
 		/obj/item/weapon/storage/box/autoinjectors,
@@ -241,6 +248,7 @@
 		/obj/item/device/healthanalyzer,
 		/obj/item/clothing/glasses/hud/health
 	)
+*/
 
 /obj/structure/closet/secure_closet/psychiatry
 	name = "Psychiatrist's locker"
@@ -252,7 +260,7 @@
 	icon_broken = "securemedbroken"
 	icon_off = "securemedoff"
 	req_access = list(access_psychiatrist)
-
+/*
 /obj/structure/closet/secure_closet/psychiatry/WillContain()
 	return list(
 		/obj/item/clothing/suit/straight_jacket,
@@ -264,3 +272,4 @@
 		/obj/item/clothing/under/rank/psych/turtleneck,
 		/obj/item/clothing/under/rank/psych
 	)
+*/

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -4,19 +4,8 @@
 	req_access = list(access_all_personal_lockers)
 	var/registered_name = null
 
-/obj/structure/closet/secure_closet/personal/WillContain()
-	return list(
-		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack, /obj/item/weapon/storage/backpack/satchel/grey)),
-		/obj/item/device/radio/headset
-	)
-
-/obj/structure/closet/secure_closet/personal/empty/WillContain()
-	return
-
 /obj/structure/closet/secure_closet/personal/patient
 	name = "patient's closet"
-/obj/structure/closet/secure_closet/personal/patient/WillContain()
-	return
 
 /obj/structure/closet/secure_closet/personal/cabinet
 	icon_state = "cabinetdetective"
@@ -25,9 +14,6 @@
 	icon_opened = "cabinetdetective_open"
 	icon_broken = "cabinetdetective_broken"
 	icon_off = "cabinetdetective_broken"
-
-/obj/structure/closet/secure_closet/personal/cabinet/WillContain()
-	return list(/obj/item/weapon/storage/backpack/satchel/grey/withwallet, /obj/item/device/radio/headset)
 
 /obj/structure/closet/secure_closet/personal/attackby(var/obj/item/weapon/W, var/mob/user)
 	if (src.opened)

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -7,7 +7,7 @@
 	icon_opened = "secureresopen"
 	icon_broken = "secureresbroken"
 	icon_off = "secureresoff"
-
+/*
 /obj/structure/closet/secure_closet/scientist/WillContain()
 	return list(
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/messenger/tox, /obj/item/weapon/storage/backpack/satchel_tox)),
@@ -18,6 +18,7 @@
 		/obj/item/clothing/mask/gas,
 		/obj/item/weapon/clipboard
 	)
+*/
 
 /obj/structure/closet/secure_closet/xenobio
 	name = "xenobiologist's locker"
@@ -28,7 +29,7 @@
 	icon_opened = "secureresopen"
 	icon_broken = "secureresbroken"
 	icon_off = "secureresoff"
-
+/*
 /obj/structure/closet/secure_closet/xenobio/WillContain()
 	return list(
 		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/messenger/tox, /obj/item/weapon/storage/backpack/satchel_tox)),
@@ -40,6 +41,7 @@
 		/obj/item/clothing/gloves/latex,
 		/obj/item/weapon/clipboard
 	)
+*/
 
 /obj/structure/closet/secure_closet/RD
 	name = "research director's locker"
@@ -50,7 +52,7 @@
 	icon_opened = "rdsecureopen"
 	icon_broken = "rdsecurebroken"
 	icon_off = "rdsecureoff"
-
+/*
 /obj/structure/closet/secure_closet/RD/WillContain()
 	return list(
 		/obj/item/clothing/suit/bio_suit/scientist = 2,
@@ -69,11 +71,12 @@
 		/obj/item/weapon/clipboard,
 		/obj/item/clothing/suit/storage/toggle/labcoat/rd
 	)
+*/
 
 /obj/structure/closet/secure_closet/animal
 	name = "animal control closet"
 	req_access = list(access_research)
-
+/*
 /obj/structure/closet/secure_closet/animal/WillContain()
 	return list(
 		/obj/item/device/assembly/signaler,
@@ -84,3 +87,4 @@
 		/obj/item/weapon/reagent_containers/glass/bottle/chloralhydrate,
 		/obj/item/weapon/reagent_containers/glass/bottle/stoxin
 	)
+*/

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -53,7 +53,12 @@
 		/obj/item/device/flash
 	)
 */
-
+/obj/structure/closet/secure_closet/hop/WillContain()
+	return list(
+		/obj/item/weapon/storage/box/ids = 1,
+		/obj/item/device/pda = 2
+	)
+		
 /obj/structure/closet/secure_closet/hop2
 	name = "head of personnel's attire"
 	req_access = list(access_hop)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -7,7 +7,7 @@
 	icon_opened = "capsecureopen"
 	icon_broken = "capsecurebroken"
 	icon_off = "capsecureoff"
-
+/*
 /obj/structure/closet/secure_closet/captains/WillContain()
 	return list(
 		new/datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/captain, /obj/item/weapon/storage/backpack/satchel_cap)),
@@ -29,6 +29,7 @@
 		/obj/item/clothing/head/caphat/formal,
 		/obj/item/clothing/under/captainformal,
 	)
+*/
 
 /obj/structure/closet/secure_closet/hop
 	name = "head of personnel's locker"
@@ -39,7 +40,7 @@
 	icon_opened = "hopsecureopen"
 	icon_broken = "hopsecurebroken"
 	icon_off = "hopsecureoff"
-
+/*
 /obj/structure/closet/secure_closet/hop/WillContain()
 	return list(
 		/obj/item/clothing/glasses/sunglasses,
@@ -51,6 +52,7 @@
 		/obj/item/weapon/gun/projectile/sec/flash,
 		/obj/item/device/flash
 	)
+*/
 
 /obj/structure/closet/secure_closet/hop2
 	name = "head of personnel's attire"
@@ -61,7 +63,7 @@
 	icon_opened = "hopsecureopen"
 	icon_broken = "hopsecurebroken"
 	icon_off = "hopsecureoff"
-
+/*
 /obj/structure/closet/secure_closet/hop2/WillContain()
 	return list(
 		/obj/item/clothing/under/rank/head_of_personnel,
@@ -78,6 +80,7 @@
 		/obj/item/clothing/under/rank/head_of_personnel_whimsy,
 		/obj/item/clothing/head/caphat/hop
 	)
+*/
 
 /obj/structure/closet/secure_closet/hos
 	name = "head of security's locker"
@@ -88,7 +91,7 @@
 	icon_opened = "hossecureopen"
 	icon_broken = "hossecurebroken"
 	icon_off = "hossecureoff"
-
+/*
 /obj/structure/closet/secure_closet/hos/WillContain()
 	return list(
 		new/datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel_sec)),
@@ -116,6 +119,7 @@
 		/obj/item/clothing/head/beret/sec/corporate/hos,
 		/obj/item/device/holowarrant
 	)
+*/
 
 /obj/structure/closet/secure_closet/warden
 	name = "warden's locker"
@@ -126,7 +130,7 @@
 	icon_opened = "wardensecureopen"
 	icon_broken = "wardensecurebroken"
 	icon_off = "wardensecureoff"
-
+/*
 /obj/structure/closet/secure_closet/warden/WillContain()
 	return list(
 		new/datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel_sec)),
@@ -152,6 +156,7 @@
 		/obj/item/clothing/head/beret/sec/corporate/warden,
 		/obj/item/device/holowarrant
 	)
+*/
 
 /obj/structure/closet/secure_closet/security
 	name = "security officer's locker"
@@ -162,7 +167,7 @@
 	icon_opened = "secopen"
 	icon_broken = "secbroken"
 	icon_off = "secoff"
-
+/*
 /obj/structure/closet/secure_closet/security/WillContain()
 	return list(
 		new/datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel_sec)),
@@ -205,6 +210,7 @@
 			/obj/item/clothing/accessory/armband/medgreen,
 			/obj/item/device/encryptionkey/headset_med
 		))
+*/
 
 /obj/structure/closet/secure_closet/detective
 	name = "detective's cabinet"
@@ -215,7 +221,7 @@
 	icon_opened = "cabinetdetective_open"
 	icon_broken = "cabinetdetective_broken"
 	icon_off = "cabinetdetective_broken"
-
+/*
 /obj/structure/closet/secure_closet/detective/WillContain()
 	return list(
 		/obj/item/clothing/under/det,
@@ -240,30 +246,32 @@
 		/obj/item/weapon/storage/briefcase/crimekit,
 		/obj/item/device/holowarrant
 	)
+*/
 
 /obj/structure/closet/secure_closet/injection
 	name = "lethal injections locker"
 	req_access = list(access_captain)
 
 /obj/structure/closet/secure_closet/injection/WillContain()
-	return list(/obj/item/weapon/reagent_containers/syringe/ld50_syringe/choral = 2)
+	return list(/obj/item/weapon/reagent_containers/syringe/ld50_syringe/choral = 1)
 
 /obj/structure/closet/secure_closet/brig
 	name = "brig locker"
 	req_access = list(access_brig)
 	anchored = 1
 	var/id = null
-
+/*
 /obj/structure/closet/secure_closet/brig/WillContain()
 	return list(
 		/obj/item/clothing/under/color/orange,
 		/obj/item/clothing/shoes/orange
 	)
+*/
 
 /obj/structure/closet/secure_closet/courtroom
 	name = "courtroom locker"
 	req_access = list(access_lawyer)
-
+/*
 /obj/structure/closet/secure_closet/courtroom/WillContain()
 	return list(
 		/obj/item/clothing/shoes/brown,
@@ -273,6 +281,7 @@
 		/obj/item/clothing/head/powdered_wig ,
 		/obj/item/weapon/storage/briefcase,
 	)
+*/
 
 /obj/structure/closet/secure_closet/wall
 	name = "wall locker"
@@ -291,7 +300,7 @@
 /obj/structure/closet/secure_closet/lawyer
 	name = "internal affairs secure closet"
 	req_access = list(access_lawyer)
-
+/*
 /obj/structure/closet/secure_closet/lawyer/WillContain()
 	return list(
 		/obj/item/device/flash = 2,
@@ -300,3 +309,4 @@
 		/obj/item/device/taperecorder = 2,
 		/obj/item/weapon/storage/secure/briefcase = 2,
 	)
+*/

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -266,9 +266,10 @@
 		icon_state = icon_opened
 
 /obj/structure/closet/shipping_wall/filled
-
+/*
 /obj/structure/closet/shipping_wall/filled/WillContain()
 	return list(
 		/obj/item/stack/material/cardboard/ten,
 		/obj/item/device/destTagger,
 		/obj/item/weapon/packageWrap)
+*/

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -242,12 +242,12 @@
 		icon_state = icon_opened
 
 /obj/structure/closet/medical_wall/filled
-
+/*
 /obj/structure/closet/medical_wall/filled/WillContain()
 	return list(
 		/obj/random/firstaid,
 		/obj/random/medical/lite = 12)
-
+*/
 /obj/structure/closet/shipping_wall
 	name = "shipping supplies closet"
 	desc = "It's a wall-mounted storage unit containing supplies for preparing shipments."

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -126,16 +126,16 @@ obj/structure/closet/crate
 	icon_state = "crate"
 	icon_opened = "crateopen"
 	icon_closed = "crate"
-
+/*
 /obj/structure/closet/crate/rcd/WillContain()
 	return list(
 		/obj/item/weapon/rcd_ammo = 3,
 		/obj/item/weapon/rcd
 	)
-
+*/
 /obj/structure/closet/crate/solar
 	name = "solar pack crate"
-
+/*
 /obj/structure/closet/crate/solar/WillContain()
 	return list(
 		/obj/item/solar_assembly = 14,
@@ -143,13 +143,13 @@ obj/structure/closet/crate
 		/obj/item/weapon/tracker_electronics,
 		/obj/item/weapon/paper/solar
 	)
-
+*/
 /obj/structure/closet/crate/solar_assembly
 	name = "solar assembly crate"
-
+/*
 /obj/structure/closet/crate/solar_assembly/WillContain()
 	return list(/obj/item/solar_assembly = 16)
-
+*/
 /obj/structure/closet/crate/freezer
 	name = "freezer"
 	desc = "A freezer."
@@ -172,10 +172,9 @@ obj/structure/closet/crate
 			newgas.temperature = target_temp
 		return newgas
 
-/obj/structure/closet/crate/freezer/rations //Fpr use in the escape shuttle
+/obj/structure/closet/crate/freezer/rations
 	name = "emergency rations"
 	desc = "A crate of emergency rations."
-
 
 /obj/structure/closet/crate/freezer/rations/WillContain()
 	return list(/obj/item/weapon/reagent_containers/food/snacks/liquidfood = 4)
@@ -200,10 +199,10 @@ obj/structure/closet/crate
 	icon_state = "radiation"
 	icon_opened = "radiationopen"
 	icon_closed = "radiation"
-
+/*
 /obj/structure/closet/crate/radiation_gear/WillContain()
 	return list(/obj/item/clothing/suit/radiation = 8)
-
+*/
 /obj/structure/closet/crate/secure/weapon
 	name = "weapons crate"
 	desc = "A secure weapons crate."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Keeps the lockers, but stops spawning of items wherever the lockers are. Some lockers still spawn items:
*Russian Lockers
*Thunderdome Lockers
*HoP's Locker spawns a ID box and a 2 PDAs
*Doesn't touch wardrobes
*Anything with the New() tag instead of WillSpawn()