### PR TITLE
Don't label new custom intercoms General

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -1,5 +1,5 @@
 /obj/item/device/radio/intercom
-	name = "intercom (General)"
+	name = "intercom"
 	desc = "Talk through this."
 	icon_state = "intercom"
 	randpixel = 0


### PR DESCRIPTION
Instead, let their builders label them with the channel they are set to.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
