### PR TITLE
Organ Tweaks

### DIFF
--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -697,7 +697,7 @@
 	name = "banana"
 	seed_name = "banana"
 	display_name = "banana tree"
-	chems = list(/datum/reagent/drink/juice/banana = list(10,10))
+	chems = list(/datum/reagent/drink/juice/banana = list(10,10), /datum/reagent/potassium = list(2,3))
 	trash_type = /obj/item/weapon/bananapeel
 	kitchen_tag = "banana"
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -26,21 +26,6 @@ meteor_act
 	var/armor = getarmor_organ(organ, P.check_armour)
 	var/penetrating_damage = ((P.damage + P.armor_penetration) * P.penetration_modifier) - armor
 
-	//Organ damage
-	if(organ.internal_organs.len && prob(35 + max(penetrating_damage, -12.5)))
-		var/damage_amt = min((P.damage * P.penetration_modifier), penetrating_damage) //So we don't factor in armor_penetration as additional damage
-		if(damage_amt > 0)
-		// Damage an internal organ
-			var/list/victims = list()
-			var/list/possible_victims = shuffle(organ.internal_organs.Copy())
-			for(var/obj/item/organ/internal/I in possible_victims)
-				if(I.damage < I.max_damage && (prob((I.relative_size) * (1 / max(1, victims.len)))))
-					victims += I
-			if(victims.len)
-				for(var/obj/item/organ/victim in victims)
-					damage_amt /= 2
-					victim.take_damage(damage_amt)
-
 	//Embed or sever artery
 	if(P.can_embed() && !(species.flags & NO_EMBED) && prob(22.5 + max(penetrating_damage, -10)) && !(prob(50) && (organ.sever_artery())))
 		var/obj/item/weapon/material/shard/shrapnel/SP = new()

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1261,14 +1261,17 @@ Note that amputating the affected organ does in fact remove the infection from t
 		else
 			wound_descriptors[this_wound_desc] = W.amount
 
-	if(open() >= (encased ? SURGERY_ENCASED : SURGERY_RETRACTED))
-		var/list/bits = list()
+	if(open() >= SURGERY_RETRACTED)
+		var/bone = encased ? encased : "bone"
 		if(status & ORGAN_BROKEN)
-			bits += "broken bones"
-		for(var/obj/item/organ/organ in internal_organs)
-			bits += "[organ.damage ? "damaged " : ""][organ.name]"
-		if(bits.len)
-			wound_descriptors["[english_list(bits)] visible in the wounds"] = 1
+			bone = "broken [bone]"
+		wound_descriptors["a [bone] exposed"] = 1
+		if(!encased || open() >= SURGERY_ENCASED)
+			var/list/bits = list()
+			for(var/obj/item/organ/internal/organ in internal_organs)
+				bits += organ.get_visible_state()
+			if(bits.len)
+				wound_descriptors["[english_list(bits)] visible in the wounds"] = 1
 
 	for(var/wound in wound_descriptors)
 		switch(wound_descriptors[wound])

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -30,7 +30,7 @@
 			spillover = brute_dam + burn_dam + brute + burn - max_damage
 			if(spillover > 0)
 				burn -= spillover
-	if(!owner) 
+	if(!owner)
 		qdel(src)
 		return
 	owner.updatehealth() //droplimb will call updatehealth() again if it does end up being called
@@ -77,25 +77,32 @@
 					return
 
 	// High brute damage or sharp objects may damage internal organs
-	var/damage_amt = brute
-	var/cur_damage = brute_dam
-	if(laser)
-		damage_amt += burn
-		cur_damage += burn_dam
-	if(internal_organs && internal_organs.len && (cur_damage + damage_amt >= max_damage || (((sharp && damage_amt >= 5) || damage_amt >= 10) && prob(5))))
-		// Damage an internal organ
-		var/list/victims = list()
-		for(var/obj/item/organ/internal/I in internal_organs)
-			if(I.damage < I.max_damage && prob(I.relative_size))
-				victims += I
-		if(!victims.len)
-			victims += pick(internal_organs)
-		for(var/obj/item/organ/victim in victims)
-			brute /= 2
-			if(laser)
-				burn /= 2
-			damage_amt /= 2
-			victim.take_damage(damage_amt)
+	if(internal_organs && internal_organs.len)
+		var/damage_amt = brute
+		var/cur_damage = brute_dam
+		if(laser)
+			damage_amt += burn
+			cur_damage += burn_dam
+		var/organ_damage_threshold = 10
+		if(sharp)
+			organ_damage_threshold *= 0.5
+		var/organ_damage_prob = 5 * damage_amt/organ_damage_threshold //more damage, higher chance to damage
+		if(encased && !(status & ORGAN_BROKEN)) //ribs protect
+			organ_damage_prob *= 0.5
+		if ((cur_damage + damage_amt >= max_damage || damage_amt >= organ_damage_threshold) && prob(organ_damage_prob))
+			// Damage an internal organ
+			var/list/victims = list()
+			for(var/obj/item/organ/internal/I in internal_organs)
+				if(I.damage < I.max_damage && prob(I.relative_size))
+					victims += I
+			if(!victims.len)
+				victims += pick(internal_organs)
+			for(var/obj/item/organ/victim in victims)
+				brute /= 2
+				if(laser)
+					burn /= 2
+				damage_amt /= 2
+				victim.take_damage(damage_amt)
 
 	if(status & ORGAN_BROKEN && brute)
 		jostle_bone(brute)

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -135,3 +135,19 @@
 				if(damage < 5)
 					degree = " a bit"
 				owner.custom_pain("Something inside your [parent.name] hurts[degree].", amount, affecting = parent)
+
+/obj/item/organ/internal/proc/get_visible_state()
+	if(damage > max_damage)
+		. = "bits and pieces of a destroyed "
+	else if(is_broken())
+		. = "broken "
+	else if(is_bruised())
+		. = "badly damaged "
+	else if(damage > 5)
+		. = "damaged "
+	if(status & ORGAN_DEAD)
+		if(can_recover())
+			. = "decaying [.]"
+		else
+			. = "necrotic [.]"
+	. = "[.][name]"

--- a/code/modules/organs/internal/kidneys.dm
+++ b/code/modules/organs/internal/kidneys.dm
@@ -28,6 +28,13 @@
 		else if(is_broken())
 			owner.adjustToxLoss(0.3)
 
+	if(is_bruised())
+		if(prob(5) && reagents.get_reagent_amount(/datum/reagent/potassium) < 5)
+			reagents.add_reagent(/datum/reagent/potassium, REM*5)
+	if(is_broken())
+		if(owner.reagents.get_reagent_amount(/datum/reagent/potassium) < 15)
+			owner.reagents.add_reagent(/datum/reagent/potassium, REM*2)
+
 	//If your kidneys aren't working, your body's going to have a hard time cleaning your blood.
 	if(!owner.reagents.has_reagent(/datum/reagent/dylovene))
 		if(prob(33))

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -43,9 +43,12 @@
 	else if(owner.chem_effects[CE_ANTITOX])
 		filter_effect += 1
 
-	// If you're not filtering well, you're going to take damage. Even more if you have alcohol in you.
+	// If you're not filtering well, you're in trouble. Ammonia buildup to toxic levels and damage from alcohol
 	if(filter_effect < 2)
-		owner.adjustToxLoss(0.5 * max(2 - filter_effect, 0) * (1 + owner.chem_effects[CE_ALCOHOL_TOXIC] + 0.5 * owner.chem_effects[CE_ALCOHOL]))
+		if(owner.reagents.get_reagent_amount(/datum/reagent/ammonia) < 6)
+			owner.reagents.add_reagent(/datum/reagent/ammonia, REM)
+		if(owner.chem_effects[CE_ALCOHOL])
+			owner.adjustToxLoss(0.5 * max(2 - filter_effect, 0) * (owner.chem_effects[CE_ALCOHOL_TOXIC] + 0.5 * owner.chem_effects[CE_ALCOHOL]))
 
 	if(owner.chem_effects[CE_ALCOHOL_TOXIC])
 		take_damage(owner.chem_effects[CE_ALCOHOL_TOXIC], prob(90)) // Chance to warn them

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -247,6 +247,12 @@
 	reagent_state = SOLID
 	color = "#a0a0a0"
 
+/datum/reagent/potassium/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(volume > 3)
+		M.add_chemical_effect(CE_PULSE, 1)
+	if(volume > 10)
+		M.add_chemical_effect(CE_PULSE, 1)
+
 /datum/reagent/radium
 	name = "Radium"
 	description = "Radium is an alkaline earth metal. It is extremely radioactive."


### PR DESCRIPTION
Liver now builds up toxins (ammonia) instead of dealing straight damage when it's hurt. This can be combated with dialysis.

Kidneys work similarly, but they build up potassium, which can be dangerous if left unchecked, and increases heart rate.

Bananas now have a little potassium.

Internal organs no longer take damage twice from bullets, and ribs provide a little protection.

Now you can see bones when you have wounds that would be considered retracted, and ascertain the state of organs by looking at them, instead of having to scan the patient to see that their lungs aren't supposed to look like that.

This PR is based on the following Baystation12 PRs:
https://github.com/Baystation12/Baystation12/pull/20856
https://github.com/Baystation12/Baystation12/pull/20857
https://github.com/Baystation12/Baystation12/pull/20858