### PR TITLE
Fix the camera system to allow public and starter faction cams

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -43,6 +43,8 @@ var/global/defer_powernet_rebuild = 0      // True if net rebuild will be called
 #define NETWORK_ROBOTS "Robots"
 #define NETWORK_SECURITY "Security"
 #define NETWORK_THUNDER "Thunderdome"
+// Camera networks for Persistence
+#define NETWORK_PUBLIC "Public"
 
 #define NETWORK_ALARM_ATMOS "Atmosphere Alarms"
 #define NETWORK_ALARM_CAMERA "Camera Alarms"

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -22,6 +22,9 @@
 /obj/machinery/camera/network/thunder
 	network = list(NETWORK_THUNDER)
 
+/obj/machinery/camera/network/public
+	network = list(NETWORK_PUBLIC)
+
 // EMP
 
 /obj/machinery/camera/emp_proof/Initialize()

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -1,26 +1,20 @@
-// Returns which access is relevant to passed network. Used by the program.
-/proc/get_camera_access(var/network)
+// Returns whether a network is faction restricted
+/proc/is_faction_restricted(var/network)
 	if(!network)
 		return 0
-	. = GLOB.using_map.get_network_access(network)
+	. = GLOB.using_map.(network)
 	if(.)
 		return
 
 	switch(network)
-		if(NETWORK_ENGINEERING, NETWORK_ALARM_ATMOS, NETWORK_ALARM_CAMERA, NETWORK_ALARM_FIRE, NETWORK_ALARM_POWER)
-			return access_engine
-		if(NETWORK_CRESCENT, NETWORK_ERT)
-			return access_cent_specops
-		if(NETWORK_MEDICAL)
-			return access_medical
-		if(NETWORK_MINE)
-			return access_mailsorting // Cargo office - all cargo staff should have access here.
-		if(NETWORK_RESEARCH)
-			return core_access_science_programs
-		if(NETWORK_THUNDER)
+		if(NETWORK_NT)
+			return 1
+		if(NETWORK_REFUGEE)
+			return 1
+		if(NETWORK_PUBLIC) // Let people create public news channels! Horray!
 			return 0
 
-	return access_security // Default for all other networks
+	return 1 // Assume faction restriction
 
 /datum/computer_file/program/camera_monitor
 	filename = "cammon"
@@ -28,7 +22,7 @@
 	nanomodule_path = /datum/nano_module/camera_monitor
 	program_icon_state = "cameras"
 	program_menu_icon = "search"
-	extended_desc = "This program allows remote access to the camera system. Some camera networks may have additional access requirements."
+	extended_desc = "This program allows security personnel remote access to the camera system of the connected network."
 	size = 12
 	available_on_ntnet = 1
 	requires_ntnet = 1
@@ -40,6 +34,14 @@
 
 /datum/nano_module/camera_monitor/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, state = GLOB.default_state)
 	var/list/data = host.initial_data()
+	var/datum/world_faction/connected_faction
+
+	if(program && program.computer.network_card && program.computer.network_card.connected_network)
+		connected_faction = program.computer.network_card.connected_network.holder
+	if(connected_faction)
+		data["faction_uid"] = connected_faction.uid
+		data["faction_name"] = connected_faction.name
+		data["faction_netuid"] = connected_faction.network_uid
 
 	data["current_camera"] = current_camera ? current_camera.nano_structure() : null
 	data["current_network"] = current_network
@@ -48,11 +50,13 @@
 	for(var/network in GLOB.using_map.station_networks)
 		all_networks.Add(list(list(
 							"tag" = network,
-							"has_access" = can_access_network(user, get_camera_access(network))
+							"has_access" = can_access_network(user, network, connected_faction, is_faction_restricted(network))
 							)))
+	
+	// .Add faction networks to all_networks here
+	// be sure to check_access(user, 5, connected_faction.uid)
 
 	all_networks = modify_networks_list(all_networks)
-
 	data["networks"] = all_networks
 
 	if(current_network)
@@ -72,12 +76,17 @@
 /datum/nano_module/camera_monitor/proc/modify_networks_list(var/list/networks)
 	return networks
 
-/datum/nano_module/camera_monitor/proc/can_access_network(var/mob/user, var/network_access)
-	// No access passed, or 0 which is considered no access requirement. Allow it.
-	if(!network_access)
+/datum/nano_module/camera_monitor/proc/can_access_network(var/user, var/network, var/connected_faction, var/restricted)
+	// Anyone can view public networks
+	if(!restricted)
 		return 1
 
-	return check_access(user, access_security) || check_access(user, network_access)
+	// If it's a network that matches the connected faction net uid ('nt_net'), it is the security network for that faction
+	if(network == connected_faction.network_uid)
+		return check_access(user, 5, connected_faction.uid)
+
+	// Otherwise it is someone else's, refuse access
+	return 0
 
 /datum/nano_module/camera_monitor/Topic(href, href_list)
 	if(..())
@@ -94,8 +103,8 @@
 		return 1
 
 	else if(href_list["switch_network"])
-		// Either security access, or access to the specific camera network's department is required in order to access the network.
-		if(can_access_network(usr, get_camera_access(href_list["switch_network"])))
+		// Security access is required in order to access the network.
+		if(can_access_network(usr, href_list["switch_network"], connected_faction, is_faction_restricted(href_list["switch_network"])))
 			current_network = href_list["switch_network"]
 		else
 			to_chat(usr, "\The [nano_host()] shows an \"Network Access Denied\" error message.")
@@ -171,6 +180,35 @@
 	networks.Add(list(list("tag" = NETWORK_ERT, "has_access" = 1)))
 	networks.Add(list(list("tag" = NETWORK_CRESCENT, "has_access" = 1)))
 	return networks
+
+/datum/nano_module/camera_monitor/apply_visual(mob/M)
+	if(current_camera)
+		current_camera.apply_visual(M)
+	else
+		remove_visual(M)
+
+/datum/nano_module/camera_monitor/remove_visual(mob/M)
+	if(current_camera)
+		current_camera.remove_visual(M)
+
+// Public variant of the camera program
+/datum/computer_file/program/camera_monitor/tv
+	filename = "tv"
+	filedesc = "Television"
+	extended_desc = "This program allows the reception of broadcast television."
+	size = 4
+	nanomodule_path = /datum/nano_module/camera_monitor/tv
+	available_on_ntnet = 1
+
+/datum/nano_module/camera_monitor/tv
+	name = "Television"
+	available_to_ai = FALSE
+
+// The television variant has access only to the Public network
+/datum/nano_module/camera_monitor/tv/modify_networks_list(var/list/networks)
+	var/list/public_networks[0]
+	public_networks.Add(list(list("tag" = NETWORK_PUBLIC, "has_access" = 1)))
+	return public_networks
 
 /datum/nano_module/camera_monitor/apply_visual(mob/M)
 	if(current_camera)

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -52,7 +52,7 @@
 							"tag" = network,
 							"has_access" = can_access_network(user, network, connected_faction, is_faction_restricted(network))
 							)))
-	
+
 	// .Add faction networks to all_networks here
 	// be sure to check_access(user, 5, connected_faction.uid)
 
@@ -209,13 +209,3 @@
 	var/list/public_networks[0]
 	public_networks.Add(list(list("tag" = NETWORK_PUBLIC, "has_access" = 1)))
 	return public_networks
-
-/datum/nano_module/camera_monitor/apply_visual(mob/M)
-	if(current_camera)
-		current_camera.apply_visual(M)
-	else
-		remove_visual(M)
-
-/datum/nano_module/camera_monitor/remove_visual(mob/M)
-	if(current_camera)
-		current_camera.remove_visual(M)

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -2,9 +2,6 @@
 /proc/is_faction_restricted(var/network)
 	if(!network)
 		return 0
-	. = GLOB.using_map.(network)
-	if(.)
-		return
 
 	switch(network)
 		if(NETWORK_NT)
@@ -76,7 +73,7 @@
 /datum/nano_module/camera_monitor/proc/modify_networks_list(var/list/networks)
 	return networks
 
-/datum/nano_module/camera_monitor/proc/can_access_network(var/user, var/network, var/connected_faction, var/restricted)
+/datum/nano_module/camera_monitor/proc/can_access_network(var/mob/user, var/network, var/connected_faction, var/restricted)
 	// Anyone can view public networks
 	if(!restricted)
 		return 1

--- a/maps/vignette/vignette.dm
+++ b/maps/vignette/vignette.dm
@@ -11,6 +11,7 @@
 
 	#include "vignette_areas.dm"
 	#include "vignette_elevator.dm"
+	#include "vignette_presets.dm"
 	#define using_map_DATUM /datum/map/vignette
 
 #elif !defined(MAP_OVERRIDE)

--- a/maps/vignette/vignette_presets.dm
+++ b/maps/vignette/vignette_presets.dm
@@ -1,0 +1,18 @@
+var/const/NETWORK_PUBLIC      = "Public"
+var/const/NETWORK_NT      	  = "nt_net"
+var/const/NETWORK_REFUGEE     = "freenet"
+
+/datum/map/vignette
+	// Networks that will show up as options in the camera monitor program
+	station_networks = list(
+		NETWORK_PUBLIC,
+		NETWORK_NT,
+		NETWORK_REFUGEE,
+	)
+
+// Networks
+/obj/machinery/camera/network/nt
+	network = list(NETWORK_NT)
+
+/obj/machinery/camera/network/refugee
+	network = list(NETWORK_REFUGEE)


### PR DESCRIPTION
What I'm trying to do:
- Add the 'nt_net' and 'freenet' security camera networks for each of the default factions.
- Require security program access (5) in the appropriate faction to access.
- Add a 'Public' network for public broadcasts.
- Add a 'Television' program which does nothing but consume Public cameras.

What I'm not trying to do:
- Add full camera support for custom factions.