### PR TITLE
Add personal lockers, patient closets, cabinets

### DIFF
--- a/code/datums/supplypacks/operations.dm
+++ b/code/datums/supplypacks/operations.dm
@@ -430,3 +430,21 @@
 	cost = 6
 	containertype = /obj/structure/closet/lawcloset
 	containername = "Bureaucrat Equipment"
+/decl/hierarchy/supply_pack/operations/personal
+	name = "Personal Locker"
+	contains = list() 
+	cost = 2
+	containertype = /obj/structure/closet/secure_closet/personal/empty
+	containername = "Personal Locker"
+/decl/hierarchy/supply_pack/operations/patient
+	name = "Patient's Closet"
+	contains = list() 
+	cost = 2
+	containertype = /obj/structure/closet/secure_closet/personal/patient
+	containername = "Patient's Closet"
+/decl/hierarchy/supply_pack/operations/personal_cabinet
+	name = "Personal Cabinet"
+	contains = list() 
+	cost = 2
+	containertype = /obj/structure/closet/secure_closet/personal/cabinet/empty
+	containername = "Personal Cabinet"

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -1,7 +1,7 @@
 /obj/structure/closet/secure_closet/personal
 	name = "personal closet"
 	desc = "It's a secure locker for personnel. The first card swiped gains control."
-	req_access = list(access_all_personal_lockers)
+	req_access = list(core_access_command_programs) // Command Staff may approve locker searching/resetting
 	var/registered_name = null
 
 /obj/structure/closet/secure_closet/personal/WillContain()
@@ -28,6 +28,9 @@
 
 /obj/structure/closet/secure_closet/personal/cabinet/WillContain()
 	return list(/obj/item/weapon/storage/backpack/satchel/grey/withwallet, /obj/item/device/radio/headset)
+
+/obj/structure/closet/secure_closet/personal/cabinet/empty/WillContain()
+	return
 
 /obj/structure/closet/secure_closet/personal/attackby(var/obj/item/weapon/W, var/mob/user)
 	if (src.opened)


### PR DESCRIPTION
You can order them in the Operations section of supply, and they arrive empty. First scanned ID card assigns their name to the locker, and after that, only they will be able to use it. Crew with Core Command Programs access may override a locker's assignment and reset its ownership.