### PR TITLE
Add imported cigs, custom cigs, and gambling

### DIFF
--- a/code/datums/supplypacks/hospitality.dm
+++ b/code/datums/supplypacks/hospitality.dm
@@ -21,6 +21,24 @@
 	cost = 15
 	containername = "\improper Party equipment"
 
+/decl/hierarchy/supply_pack/hospitality/cigarettes
+	num_contained = 4
+	name = "Imported cigarettes"
+	contains = list(
+			/obj/item/weapon/storage/fancy/cigarettes,
+			/obj/item/weapon/storage/fancy/cigarettes/dromedaryco,
+			/obj/item/weapon/storage/fancy/cigarettes/killthroat,
+			/obj/item/weapon/storage/fancy/cigarettes/luckystars,
+			/obj/item/weapon/storage/fancy/cigarettes/jerichos,
+			/obj/item/weapon/storage/fancy/cigarettes/menthols,
+			/obj/item/weapon/storage/fancy/cigarettes/carcinomas,
+			/obj/item/weapon/storage/fancy/cigarettes/professionals,
+			/obj/item/weapon/flame/lighter,
+			/obj/item/weapon/flame/lighter/zippo)
+	cost = 30
+	containername = "\improper Imported cigarettes"
+	supply_method = /decl/supply_method/randomized
+
 /decl/hierarchy/supply_pack/hospitality/barsupplies
 	name = "Bar supplies"
 	contains = list(

--- a/code/datums/supplypacks/miscellaneous.dm
+++ b/code/datums/supplypacks/miscellaneous.dm
@@ -121,6 +121,13 @@
 	containertype = /obj/structure/closet
 	containername = "\improper Formalwear for the best occasions."
 
+/decl/hierarchy/supply_pack/miscellaneous/gambling
+	contains = list(/obj/item/weapon/deck/cards,
+					/obj/item/weapon/dice = 4)
+	name = "\improper Gambling Crate"
+	cost = 5
+	containername = "\improper gambling crate"
+
 /decl/hierarchy/supply_pack/miscellaneous/card_packs
 	num_contained = 5
 	contains = list(/obj/item/weapon/pack/cardemon,

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -243,6 +243,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			M.remove_from_mob(src) //un-equip it so the overlays can update
 		qdel(src)
 
+/obj/item/clothing/mask/smokable/cigarette/custom
+	name = "hand-rolled cigarette"
+	desc = "A tightly rolled smokeable, ready to deliver whatever it's been dipped in."
+	filling = list() // Starts with nothing, dip it in a reageant to finish.
+	color = "#dcdcdc"
+
 /obj/item/clothing/mask/smokable/cigarette/menthol
 	name = "menthol cigarette"
 	desc = "A cigarette with a little minty kick. Well, minty in theory."

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -27,6 +27,10 @@
 	max_storage_space = DEFAULT_BOX_STORAGE
 	var/foldable = /obj/item/stack/material/cardboard	// BubbleWrap - if set, can be folded (when empty) into a sheet of cardboard
 
+/obj/item/weapon/storage/box/cigarettes
+	name = "cigarette carton"
+	desc = "A carton of cigarettes."
+
 /obj/item/weapon/storage/box/large
 	name = "large box"
 	icon_state = "largebox"

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -174,6 +174,12 @@
 	else
 		..()
 
+/obj/item/weapon/storage/fancy/cigarettes/blank
+	name = "pack of cigarettes"
+	desc = "This is a nondescript pack for cigarettes. It looks like someone folded it by hand."
+	icon_state = "cigpacket"
+	startswith = list()
+
 /obj/item/weapon/storage/fancy/cigarettes/dromedaryco
 	name = "pack of Dromedary Co. cigarettes"
 	desc = "A packet of six imported Dromedary Company cancer sticks. A label on the packaging reads, \"Wouldn't a slow death make a change?\"."

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -176,11 +176,13 @@
 		new/datum/stack_recipe("large box", /obj/item/weapon/storage/box/large, 2), \
 		new/datum/stack_recipe("donut box", /obj/item/weapon/storage/box/donut/empty), \
 		new/datum/stack_recipe("egg box", /obj/item/weapon/storage/fancy/egg_box/empty), \
+		new/datum/stack_recipe("cigarette carton", /obj/item/weapon/storage/box/cigarettes, 4) \
 		new/datum/stack_recipe("light tubes box", /obj/item/weapon/storage/box/lights/tubes/empty), \
 		new/datum/stack_recipe("light bulbs box", /obj/item/weapon/storage/box/lights/bulbs/empty), \
 		new/datum/stack_recipe("mouse traps box", /obj/item/weapon/storage/box/mousetraps/empty), \
 		new/datum/stack_recipe("pizza box", /obj/item/pizzabox), \
 		))
+	recipes += new/datum/stack_recipe("empty cigarette", /obj/item/clothing/mask/smokable/cigarette/custom)
 	recipes += new/datum/stack_recipe("cardborg suit", /obj/item/clothing/suit/cardborg, 3)
 	recipes += new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg)
 	recipes += new/datum/stack_recipe_list("folders",list( \

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -182,6 +182,7 @@
 		new/datum/stack_recipe("mouse traps box", /obj/item/weapon/storage/box/mousetraps/empty), \
 		new/datum/stack_recipe("pizza box", /obj/item/pizzabox), \
 		))
+	recipes += new/datum/stack_recipe("empty cigarette pack", /obj/item/weapon/storage/fancy/cigarettes/blank)
 	recipes += new/datum/stack_recipe("empty cigarette", /obj/item/clothing/mask/smokable/cigarette/custom)
 	recipes += new/datum/stack_recipe("cardborg suit", /obj/item/clothing/suit/cardborg, 3)
 	recipes += new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg)


### PR DESCRIPTION
The imported cigarettes crate gives you a random group of branded cigarettes and/or lighters, but this is pretty expensive. The gambling crate gives you cards and dice. You can now use cardboard to make cigarette packs, cartons, and hand-rolled cigarettes. Dip them in a reagent to finish them.