### PR TITLE
Supply Shuttle Fix

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -249,10 +249,11 @@ var/list/point_source_descriptions = list(
 			export.rate = per
 			export.order_type = typee
 			export.id = exportnum
-			var/obj/ob = new design.build_path
-			export.name = "Order for [export.required] [ob.name]\s at [export.rate] for each item."
-			all_exports |= export
-			return export
+			if(design.build_path)
+				var/obj/ob = new design.build_path()
+				export.name = "Order for [export.required] [ob.name]\s at [export.rate] for each item."
+				all_exports |= export
+				return export
 		if("material")
 			export = new /datum/export_order/stack()
 			var/list/possible = list(


### PR DESCRIPTION
Quick patch to supply shuttles. They'd toss a runtime if the path for their thing didn't exist. This would cause Travis to fail on unrelated PRs like #106

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
