### PR TITLE
Patch for Televisions / Cameras

### DIFF
--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -6,7 +6,7 @@
 	w_class = ITEM_SIZE_LARGE
 	slot_flags = SLOT_BELT
 	var/channel = "General News Feed"
-	var/obj/machinery/camera/network/thunder/camera
+	var/obj/machinery/camera/network/public/camera
 	var/obj/item/device/radio/radio
 
 /obj/item/device/tvcamera/New()

--- a/code/modules/modular_computers/NTNet/NTNet.dm
+++ b/code/modules/modular_computers/NTNet/NTNet.dm
@@ -172,11 +172,16 @@ var/global/datum/ntnet/ntnet_global = new()
 		if(NTNET_SOFTWAREDOWNLOAD)
 			setting_softwaredownload = !setting_softwaredownload
 			add_log("Configuration Updated. Wireless network firewall now [setting_softwaredownload ? "allows" : "disallows"] connection to software repositories.")
+			if(setting_softwaredownload)
+				// If you turned it off and on again, rebuild the software list. This fetches new NTNet programs.
+				build_software_lists()
+				add_log("Software repository update complete.")
 		if(NTNET_PEERTOPEER)
 			setting_peertopeer = !setting_peertopeer
 			add_log("Configuration Updated. Wireless network firewall now [setting_peertopeer ? "allows" : "disallows"] peer to peer network traffic.")
 		if(NTNET_COMMUNICATION)
 			setting_communication = !setting_communication
+			if setting_softwaredownload
 			add_log("Configuration Updated. Wireless network firewall now [setting_communication ? "allows" : "disallows"] instant messaging and similar communication services.")
 		if(NTNET_SYSTEMCONTROL)
 			setting_systemcontrol = !setting_systemcontrol

--- a/code/modules/modular_computers/NTNet/NTNet.dm
+++ b/code/modules/modular_computers/NTNet/NTNet.dm
@@ -181,7 +181,9 @@ var/global/datum/ntnet/ntnet_global = new()
 			add_log("Configuration Updated. Wireless network firewall now [setting_peertopeer ? "allows" : "disallows"] peer to peer network traffic.")
 		if(NTNET_COMMUNICATION)
 			setting_communication = !setting_communication
-			if setting_softwaredownload
+			if(setting_communication)
+				build_news_list()
+				add_log("News repository updated.")
 			add_log("Configuration Updated. Wireless network firewall now [setting_communication ? "allows" : "disallows"] instant messaging and similar communication services.")
 		if(NTNET_SYSTEMCONTROL)
 			setting_systemcontrol = !setting_systemcontrol

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -41,7 +41,7 @@
 	for(var/network in GLOB.using_map.station_networks)
 		all_networks.Add(list(list(
 							"tag" = network,
-							"has_access" = can_access_network(user, network, connected_faction, is_faction_restricted(network))
+							"has_access" = can_access_network(user, network, is_faction_restricted(network))
 							)))
 
 	// .Add faction networks to all_networks here
@@ -197,7 +197,6 @@
 
 // The television variant has access only to the Public network
 /datum/nano_module/program/camera_monitor/tv/modify_networks_list(var/list/networks)
-	..()
 	var/list/public_networks[0]
 	public_networks.Add(list(list("tag" = NETWORK_PUBLIC, "has_access" = 1)))
 	return public_networks

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -197,6 +197,7 @@
 
 // The television variant has access only to the Public network
 /datum/nano_module/program/camera_monitor/tv/modify_networks_list(var/list/networks)
+	..()
 	var/list/public_networks[0]
 	public_networks.Add(list(list("tag" = NETWORK_PUBLIC, "has_access" = 1)))
 	return public_networks


### PR DESCRIPTION
This patches some issues with Television and Camera Monitor.

- Public network is now viewable on Camera Monitor in addition to Television
- Press camera drones now broadcast to public channel
- Software list can be refreshed by turning NTNet downloads off and on again