### PR TITLE
Pay Refugees

### DIFF
--- a/code/controllers/employment_controller.dm
+++ b/code/controllers/employment_controller.dm
@@ -13,23 +13,35 @@ var/datum/controller/employment_controller/employment_controller
 	. = ..()
 
 /datum/controller/employment_controller/Process()
-//	var/reset_timerbuffer = 0
 	if(round_duration_in_ticks > checkbuffer)
+		// For everyone: always advance the check countdown by five minutes when logging time worked
 		checkbuffer = round_duration_in_ticks + 5 MINUTES
+
+		// For each faction...
 		for(var/datum/world_faction/connected_faction in GLOB.all_world_factions)
+
+			// LOG WORK
+			// Find neural laces that are currently connected...
 			for(var/obj/item/organ/internal/stack/stack in connected_faction.connected_laces)
+				// Find their crew record ...
 				var/datum/computer_file/crew_record/record = connected_faction.get_record(stack.get_owner_name())
 				if(!record) continue
+				// Make sure they are still on duty...
 				if(stack.duty_status)
 					for(var/mob/M in GLOB.player_list)
 						if(M.real_name == stack.get_owner_name() && M.client && M.client.inactivity <= 10 * 60 * 10)
+							// Log a five-minute unit of work on their crew record.
 							record.worked += 1	
 							break
 
 				if(round_duration_in_ticks > timerbuffer)
+					// It is payday, inform the employee they are being paid.
 					to_chat(stack.owner, "Your [stack] buzzes, letting you know that you should be getting paid.")
+
+			// PAY PEOPLE
+			// See if it is payday...
 			if(round_duration_in_ticks > timerbuffer)
-				timerbuffer = round_duration_in_ticks + 1 HOUR
+				// It is payday, pay the employee.
 				for(var/datum/computer_file/crew_record/record in connected_faction.get_records())
 					if(record.worked)
 						var/datum/assignment/assignment = connected_faction.get_assignment(record.assignment_uid)
@@ -52,5 +64,9 @@ var/datum/controller/employment_controller/employment_controller
 							else
 								connected_faction.debts[record.get_name()] = "[to_pay]"
 						record.worked = 0
+
+		// For everyone: advance the payday timer by one hour, but only if it's payday
+		if (round_duration_in_ticks > timerbuffer)
+			timerbuffer = round_duration_in_ticks + 1 HOUR
 					
 			


### PR DESCRIPTION
This code change causes refugees and other factions to be paid. They will get back pay for the time worked since that will have been logged as "worked" in their crew record.

982a513 caused payday timer to advance by one hour immediately upon issuing pay. Since NT was the first faction in the list, this was absolutely no problem for them, but by the time Refugee was evaluated, it had already become "not payday yet."