### PR TITLE
Patch for Colored Lights

### DIFF
--- a/code/datums/supplypacks/supply.dm
+++ b/code/datums/supplypacks/supply.dm
@@ -137,7 +137,7 @@
 	cost = 40
 	containername = "\improper Light Tube Crate"
 
-/decl/hierarchy/supply_pack/supply/colortubes
+/decl/hierarchy/supply_pack/supply/colorbulbs
 	name = "Colored Light Bulbs"
 	contains = list(/obj/item/weapon/light/bulb/red = 3,
 					/obj/item/weapon/light/bulb/green = 3,

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -562,30 +562,37 @@
 	brightness_power = 3
 
 /obj/item/weapon/light/tube/red
+	name = "red light tube"
 	color = "#da0205"
 	brightness_color = "#da0205"
 
 /obj/item/weapon/light/tube/green
+	name = "green light tube"
 	color = "#71da02"
 	brightness_color = "#71da02"
 
 /obj/item/weapon/light/tube/blue
+	name = "blue light tube"
 	color = "#0271da"
 	brightness_color = "#0271da"
 
 /obj/item/weapon/light/tube/purple
+	name = "purple light tube"
 	color = "#6b02da"
 	brightness_color = "#6b02da"
 
 /obj/item/weapon/light/tube/pink
+	name = "pink light tube"
 	color = "#da0271"
 	brightness_color = "#da0271"
 
 /obj/item/weapon/light/tube/yellow
+	name = "yellow light tube"
 	color = "#dad702"
 	brightness_color = "#dad702"
 
 /obj/item/weapon/light/tube/orange
+	name = "orange light tube"
 	color = "#da6b02"
 	brightness_color = "#da6b02"
 
@@ -607,30 +614,38 @@
 		)
 
 /obj/item/weapon/light/bulb/red
+	name = "red light bulb"
 	color = "#da0205"
 	brightness_color = "#da0205"
 
 /obj/item/weapon/light/bulb/green
+	name = "green light bulb"
 	color = "#71da02"
 	brightness_color = "#71da02"
 
 /obj/item/weapon/light/bulb/blue
+	name = "blue light bulb"
 	color = "#0271da"
 	brightness_color = "#0271da"
 
 /obj/item/weapon/light/bulb/purple
+	name = "purple light bulb"
 	color = "#6b02da"
 	brightness_color = "#6b02da"
 
 /obj/item/weapon/light/bulb/pink
+	name = "pink light bulb"
 	color = "#da0271"
 	brightness_color = "#da0271"
 
 /obj/item/weapon/light/bulb/yellow
+
+	name = "yellow light bulb"
 	color = "#dad702"
 	brightness_color = "#dad702"
 
 /obj/item/weapon/light/bulb/orange
+	name = "orange light bulb"
 	color = "#da6b02"
 	brightness_color = "#da6b02"
 


### PR DESCRIPTION
- Uses unique names for the colored bulb crate vs. the colored tube crate
- Makes color of each bulb / tube apparent in the name