### PR TITLE
Added peeking, who the hecking frig uses faceperm

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -736,6 +736,8 @@
 		reset_plane_and_layer()
 
 /mob/proc/facedir(var/ndir)
+	client.pixel_x = 0
+	client.pixel_y = 0
 	if(!canface() || client.moving || world.time < client.move_delay)
 		return 0
 	set_dir(ndir)
@@ -1004,6 +1006,7 @@ mob/proc/yank_out_object()
 	. = stat != new_stat
 	stat = new_stat
 
+/* lmao who needs this shit
 /mob/verb/northfaceperm()
 	set hidden = 1
 	set_face_dir(client.client_dir(NORTH))
@@ -1019,6 +1022,38 @@ mob/proc/yank_out_object()
 /mob/verb/westfaceperm()
 	set hidden = 1
 	set_face_dir(client.client_dir(WEST))
+*/
+/mob/verb/eastfaceperm()
+	set hidden = 1
+	if(!canface())	return 0
+	dir = EAST
+	if(!client)		return 0
+	client.pixel_x = min(160, client.pixel_x + 160)
+	return 1
+
+/mob/verb/northfaceperm()
+	set hidden = 1
+	if(!canface())	return 0
+	dir = NORTH
+	if(!client)		return 0
+	client.pixel_y = min(160, client.pixel_y + 160)
+	return 1
+
+/mob/verb/westfaceperm()
+	set hidden = 1
+	if(!canface())	return 0
+	dir = WEST
+	if(!client)		return 0
+	client.pixel_x = max(-160, client.pixel_x - 160)
+	return 1
+
+/mob/verb/southfaceperm()
+	set hidden = 1
+	if(!canface())	return 0
+	dir = SOUTH
+	if(!client)		return 0
+	client.pixel_y = max(-160, client.pixel_y - 160)
+	return 1
 
 /mob/proc/adjustEarDamage()
 	return


### PR DESCRIPTION
Alt+WASD in hotkey mode allows you to "throw" your eye.
Allows 5 extra turfs of sight in the chosen direction.
Works for diagonals too.
Should obey rules of visibility as that's done from the PoV from your mob.