### PR TITLE
Added peeking (alt + dir), with a rebound faceperm (alt + shift + dir)

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1006,7 +1006,7 @@ mob/proc/yank_out_object()
 	. = stat != new_stat
 	stat = new_stat
 
-/* lmao who needs this shit
+
 /mob/verb/northfaceperm()
 	set hidden = 1
 	set_face_dir(client.client_dir(NORTH))
@@ -1022,8 +1022,8 @@ mob/proc/yank_out_object()
 /mob/verb/westfaceperm()
 	set hidden = 1
 	set_face_dir(client.client_dir(WEST))
-*/
-/mob/verb/eastfaceperm()
+
+/mob/verb/eastfacepeek()
 	set hidden = 1
 	if(!canface())	return 0
 	dir = EAST
@@ -1031,7 +1031,7 @@ mob/proc/yank_out_object()
 	client.pixel_x = min(160, client.pixel_x + 160)
 	return 1
 
-/mob/verb/northfaceperm()
+/mob/verb/northfacepeek()
 	set hidden = 1
 	if(!canface())	return 0
 	dir = NORTH
@@ -1039,7 +1039,7 @@ mob/proc/yank_out_object()
 	client.pixel_y = min(160, client.pixel_y + 160)
 	return 1
 
-/mob/verb/westfaceperm()
+/mob/verb/westfacepeek()
 	set hidden = 1
 	if(!canface())	return 0
 	dir = WEST
@@ -1047,7 +1047,7 @@ mob/proc/yank_out_object()
 	client.pixel_x = max(-160, client.pixel_x - 160)
 	return 1
 
-/mob/verb/southfaceperm()
+/mob/verb/southfacepeek()
 	set hidden = 1
 	if(!canface())	return 0
 	dir = SOUTH

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -736,6 +736,8 @@
 		reset_plane_and_layer()
 
 /mob/proc/facedir(var/ndir)
+	client.pixel_x = 0
+	client.pixel_y = 0
 	if(!canface() || client.moving || world.time < client.move_delay)
 		return 0
 	set_dir(ndir)
@@ -1004,6 +1006,7 @@ mob/proc/yank_out_object()
 	. = stat != new_stat
 	stat = new_stat
 
+/* lmao who needs this shit
 /mob/verb/northfaceperm()
 	set hidden = 1
 	set_face_dir(client.client_dir(NORTH))
@@ -1019,6 +1022,38 @@ mob/proc/yank_out_object()
 /mob/verb/westfaceperm()
 	set hidden = 1
 	set_face_dir(client.client_dir(WEST))
+*/
+/mob/verb/eastfaceperm()
+	set hidden = 1
+	if(!canface())	return 0
+	dir = EAST
+	if(!client)		return 0
+	client.pixel_x = min(160, client.pixel_x + 160)
+	return 1
+
+/mob/verb/northfaceperm()
+	set hidden = 1
+	if(!canface())	return 0
+	dir = NORTH
+	if(!client)		return 0
+	client.pixel_y = min(160, client.pixel_y + 160)
+	return 1
+
+/mob/verb/westfaceperm()
+	set hidden = 1
+	if(!canface())	return 0
+	dir = WEST
+	if(!client)		return 0
+	client.pixel_x = max(-160, client.pixel_x - 160)
+	return 1
+
+/mob/verb/southfaceperm()
+	set hidden = 1
+	if(!canface())	return 0
+	dir = SOUTH
+	if(!client)		return 0
+	client.pixel_y = max(-160, client.pixel_y - 160)
+	return 1
 
 /mob/proc/adjustEarDamage()
 	return

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -221,64 +221,76 @@ macro "borghotkeymode"
 
 macro "macro"
 	elem 
-		name = "TAB"
+		name = "Tab"
 		command = ".winset \"mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true\""
 	elem 
-		name = "CENTER+REP"
+		name = "Center+REP"
 		command = ".center"
 	elem 
-		name = "NORTHEAST"
+		name = "Northeast"
 		command = ".northeast"
 	elem 
-		name = "SOUTHEAST"
+		name = "Southeast"
 		command = ".southeast"
 	elem 
-		name = "SOUTHWEST"
+		name = "Southwest"
 		command = ".southwest"
 	elem 
-		name = "NORTHWEST"
+		name = "Northwest"
 		command = ".northwest"
 	elem 
-		name = "ALT+WEST"
-		command = "westfaceperm"
+		name = "ALT+West"
+		command = "westfacepeek"
 	elem 
-		name = "CTRL+WEST"
+		name = "CTRL+West"
 		command = "westface"
 	elem 
-		name = "WEST+REP"
+		name = "ALT+SHIFT+West"
+		command = "westfaceperm"
+	elem 
+		name = "West+REP"
 		command = ".moveleft"
 	elem 
-		name = "ALT+NORTH"
-		command = "northfaceperm"
+		name = "North"
+		command = "northfacepeek"
 	elem 
-		name = "CTRL+NORTH"
+		name = "CTRL+North"
 		command = "northface"
 	elem 
-		name = "NORTH+REP"
+		name = "ALT+SHIFT+North"
+		command = "northfaceperm"
+	elem 
+		name = "North+REP"
 		command = ".moveup"
 	elem 
-		name = "ALT+EAST"
+		name = "ALT+East"
 		command = "eastfaceperm"
 	elem 
-		name = "CTRL+EAST"
+		name = "CTRL+East"
 		command = "eastface"
 	elem 
-		name = "EAST+REP"
+		name = "ALT+SHIFT+East"
+		command = "eastfaceperm"
+	elem 
+		name = "East+REP"
 		command = ".moveright"
 	elem 
-		name = "ALT+SOUTH"
-		command = "southfaceperm"
+		name = "ALT+South"
+		command = "southfacepeek"
 	elem 
-		name = "CTRL+SOUTH"
+		name = "CTRL+South"
 		command = "southface"
 	elem 
-		name = "SOUTH+REP"
+		name = "ALT+SHIFT+South"
+		command = "southfaceperm"
+	elem 
+		name = "South+REP"
 		command = ".movedown"
 	elem 
-		name = "INSERT"
+		name = "Insert"
 		command = "a-intent right"
 	elem 
-		name = "DELETE"
+		name = "Delete"
 		command = "delete-key-pressed"
 	elem 
 		name = "CTRL+1"
@@ -332,25 +344,25 @@ macro "macro"
 		name = "CTRL+Z"
 		command = "Activate-Held-Object"
 	elem 
-		name = "CTRL+NUMPAD1"
+		name = "CTRL+Numpad1"
 		command = "body-r-leg"
 	elem 
-		name = "CTRL+NUMPAD2"
+		name = "CTRL+Numpad2"
 		command = "body-groin"
 	elem 
-		name = "CTRL+NUMPAD3"
+		name = "CTRL+Numpad3"
 		command = "body-l-leg"
 	elem 
-		name = "CTRL+NUMPAD4"
+		name = "CTRL+Numpad4"
 		command = "body-r-arm"
 	elem 
-		name = "CTRL+NUMPAD5"
+		name = "CTRL+Numpad5"
 		command = "body-chest"
 	elem 
-		name = "CTRL+NUMPAD6"
+		name = "CTRL+Numpad6"
 		command = "body-l-arm"
 	elem 
-		name = "CTRL+NUMPAD8"
+		name = "CTRL+Numpad8"
 		command = "body-toggle-head"
 	elem 
 		name = "F1"
@@ -391,64 +403,76 @@ macro "macro"
 
 macro "hotkeymode"
 	elem 
-		name = "TAB"
+		name = "Tab"
 		command = ".winset \"mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true\""
 	elem 
-		name = "CENTER+REP"
+		name = "Center+REP"
 		command = ".center"
 	elem 
-		name = "NORTHEAST"
+		name = "Northeast"
 		command = ".northeast"
 	elem 
-		name = "SOUTHEAST"
+		name = "Southeast"
 		command = ".southeast"
 	elem 
-		name = "SOUTHWEST"
+		name = "Southwest"
 		command = ".southwest"
 	elem 
-		name = "NORTHWEST"
+		name = "Northwest"
 		command = ".northwest"
 	elem 
-		name = "ALT+WEST"
-		command = "westfaceperm"
+		name = "ALT+West"
+		command = "westfacepeek"
 	elem 
-		name = "CTRL+WEST"
+		name = "CTRL+West"
 		command = "westface"
 	elem 
-		name = "WEST+REP"
+		name = "ALT+SHIFT+West"
+		command = "westfaceperm"
+	elem 
+		name = "West+REP"
 		command = ".moveleft"
 	elem 
-		name = "ALT+NORTH"
-		command = "northfaceperm"
+		name = "ALT+North"
+		command = "northfacepeek"
 	elem 
-		name = "CTRL+NORTH"
+		name = "CTRL+North"
 		command = "northface"
 	elem 
-		name = "NORTH+REP"
+		name = "ALT+SHIFT+North"
+		command = "northfaceperm"
+	elem 
+		name = "North+REP"
 		command = ".moveup"
 	elem 
-		name = "ALT+EAST"
-		command = "eastfaceperm"
+		name = "ALT+East"
+		command = "eastfacepeek"
 	elem 
-		name = "CTRL+EAST"
+		name = "CTRL+East"
 		command = "eastface"
 	elem 
-		name = "EAST+REP"
+		name = "ALT+SHIFT+East"
+		command = "eastfaceperm"
+	elem 
+		name = "East+REP"
 		command = ".moveright"
 	elem 
-		name = "ALT+SOUTH"
-		command = "southfaceperm"
+		name = "ALT+South"
+		command = "southfacepeek"
 	elem 
-		name = "CTRL+SOUTH"
+		name = "CTRL+South"
 		command = "southface"
 	elem 
-		name = "SOUTH+REP"
+		name = "ALT+SHIFT+South"
+		command = "southfaceperm"
+	elem 
+		name = "South+REP"
 		command = ".movedown"
 	elem 
-		name = "INSERT"
+		name = "Insert"
 		command = "a-intent right"
 	elem 
-		name = "DELETE"
+		name = "Delete"
 		command = "delete-key-pressed"
 	elem 
 		name = "1"
@@ -478,11 +502,17 @@ macro "hotkeymode"
 		name = "5"
 		command = ".me"
 	elem 
+		name = "ALT+A"
+		command = "westfacepeek"
+	elem 
 		name = "A+REP"
 		command = ".moveleft"
 	elem 
 		name = "CTRL+A+REP"
 		command = ".moveleft"
+	elem 
+		name = "ALT+D"
+		command = "eastfacepeek"
 	elem 
 		name = "D+REP"
 		command = ".moveright"
@@ -531,6 +561,9 @@ macro "hotkeymode"
 	elem 
 		name = "CTRL+R"
 		command = ".southwest"
+	elem 
+		name = "ALT+S"
+		command = "southfacepeek"
 	elem "s_key"
 		name = "S+REP"
 		command = ".movedown"
@@ -540,6 +573,9 @@ macro "hotkeymode"
 	elem 
 		name = "T"
 		command = ".say"
+	elem 
+		name = "ALT+W"
+		command = "northfacepeek"
 	elem "w_key"
 		name = "W+REP"
 		command = ".moveup"
@@ -565,25 +601,25 @@ macro "hotkeymode"
 		name = "CTRL+Z"
 		command = "Activate-Held-Object"
 	elem 
-		name = "NUMPAD1"
+		name = "Numpad1"
 		command = "body-r-leg"
 	elem 
-		name = "NUMPAD2"
+		name = "Numpad2"
 		command = "body-groin"
 	elem 
-		name = "NUMPAD3"
+		name = "Numpad3"
 		command = "body-l-leg"
 	elem 
-		name = "NUMPAD4"
+		name = "Numpad4"
 		command = "body-r-arm"
 	elem 
-		name = "NUMPAD5"
+		name = "Numpad5"
 		command = "body-chest"
 	elem 
-		name = "NUMPAD6"
+		name = "Numpad6"
 		command = "body-l-arm"
 	elem 
-		name = "NUMPAD8"
+		name = "Numpad8"
 		command = "body-toggle-head"
 	elem 
 		name = "F1"
@@ -1096,7 +1132,6 @@ window "mainwindow"
 		size = 1038x564
 		anchor1 = none
 		anchor2 = none
-		background-color = none
 		is-default = true
 		saved-params = "pos;size;is-minimized;is-maximized"
 		icon = 'icons\\ss13_64.png'
@@ -1135,7 +1170,6 @@ window "mainwindow"
 		size = 1038x520
 		anchor1 = 0,0
 		anchor2 = 100,100
-		background-color = none
 		saved-params = "splitter"
 		right = "rpane"
 		is-vert = true
@@ -1181,7 +1215,6 @@ window "mainwindow"
 		size = 1x1
 		anchor1 = none
 		anchor2 = none
-		background-color = none
 		is-visible = false
 		saved-params = ""
 	elem "hotkey_toggle"
@@ -1190,7 +1223,6 @@ window "mainwindow"
 		size = 104x16
 		anchor1 = 100,100
 		anchor2 = none
-		background-color = none
 		border = line
 		saved-params = ""
 		text = "Hotkey Mode"


### PR DESCRIPTION
Alt+WASD in hotkey mode allows you to "throw" your eye (arrows/numpad also work).
Allows 5 extra turfs of sight in the chosen direction.
Works for diagonals too.
Should obey rules of visibility as that's done from the PoV from your mob.
Rebound faceperm to alt+shift+arrows/numpad.