### PR TITLE
Add epinephrine reaction, fix ecigs and export text

### DIFF
--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -597,7 +597,7 @@ var/const/EXTRA_COST_FACTOR = 1.25
 /datum/autolathe/recipe/ecig
 	// We get it, you vape
 	name = "ecigarette"
-	path = /obj/item/clothing/mask/smokable/ecig
+	path = /obj/item/clothing/mask/smokable/ecig/lathed
 	category = "Devices and Components"
 
 /datum/autolathe/recipe/keypad

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -21,6 +21,14 @@
 	..()
 	ec_cartridge = new cartridge_type(src)
 
+/obj/item/clothing/mask/smokable/ecig/lathed
+	name = "electronic cigarette"
+	desc = "A cheap electronic cigarette. The metal still has a few shavings from being rolled in an autolathe."
+	icon_state = "ccigoff"
+	icon_off = "ccigoff"
+	icon_empty = "ccigoff"
+	icon_on = "ccigon"
+
 /obj/item/clothing/mask/smokable/ecig/simple
 	name = "simple electronic cigarette"
 	desc = "A cheap Lucky 1337 electronic cigarette, styled like a traditional cigarette."

--- a/code/modules/modular_computers/file_system/programs/generic/supply2.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/supply2.dm
@@ -240,7 +240,7 @@
 						sent++
 					break
 				break
-		to_chat(usr, "Export protocl completed, [sent] orders were succesfully sent and [earned] $$ was put into the account.")
+		to_chat(usr, "Export protocol completed, [sent] orders were succesfully sent and [earned] $$ was put into the account.")
 	if(href_list["launch_order"])
 		if(!connected_faction.approved_orders) return
 		if(!selected_telepads.len)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -658,7 +658,7 @@
 
 /datum/reagent/rezadone
 	name = "Rezadone"
-	description = "A powder with almost magical properties, this substance can effectively treat genetic damage in humanoids, though excessive consumption has side effects."
+	description = "This remarkable emergency treatment can treat genetic damage in humanoids, but such crude regrowth of tissue is almost guaranteed to disfigure the patient."
 	taste_description = "sickness"
 	reagent_state = SOLID
 	color = "#669900"
@@ -669,13 +669,12 @@
 /datum/reagent/rezadone/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.adjustCloneLoss(-20 * removed)
 	M.adjustOxyLoss(-2 * removed)
-	M.heal_organ_damage(20 * removed, 20 * removed)
-	M.adjustToxLoss(-20 * removed)
-	if(M.chem_doses[type] > 3 && ishuman(M))
+	M.heal_organ_damage(10 * removed, 10 * removed)
+	M.adjustToxLoss(-10 * removed)
+	if(M.chem_doses[type] > 1 && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		for(var/obj/item/organ/external/E in H.organs)
 			E.disfigured = 1 //currently only matters for the head, but might as well disfigure them all.
-	if(M.chem_doses[type] > 10)
 		M.make_dizzy(5)
 		M.make_jittery(5)
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -408,7 +408,7 @@
 /datum/chemical_reaction/rezadone
 	name = "Rezadone"
 	result = /datum/reagent/rezadone
-	required_reagents = list(/datum/reagent/arithrazine, /datum/reagent/cryptobiolin = 1, /datum/reagent/copper = 1)
+	required_reagents = list(/datum/reagent/ryetalyn = 1, /datum/reagent/cryptobiolin = 1, /datum/reagent/copper = 1)
 	result_amount = 3
 
 /datum/chemical_reaction/lexorin

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -355,6 +355,12 @@
 	required_reagents = list (/datum/reagent/ammonia = 1, /datum/reagent/ethanol = 1)
 	result_amount = 2
 
+/datum/chemical_reaction/adrenaline
+	name = "Adrenaline"
+	result = /datum/reagent/adrenaline
+	required_reagents = list (/datum/reagent/hyperzine = 1, /datum/reagent/adrenaline = 1, /datum/reagent/acid/hydrochloric = 1)
+	result_amount = 3
+
 /datum/chemical_reaction/space_cleaner
 	name = "Space cleaner"
 	result = /datum/reagent/space_cleaner


### PR DESCRIPTION
- Adds adrenaline reaction (1 Adrenaline, 1 Hyperzine, 1 Hydrochloric Acid), which allows you to synthesize more epinephrine given a sample.
- Synthetic adrenaline is still dangerous for your heart and stacks with what the body naturally produces.
- Nerfs Rezadone and makes it a Ryetalyn derivative. Please don't use this drug if you don't have to, it will mess people's faces up.
- Fix a typo in exports.
- Fix vape sprites.