### PR TITLE
Numerous Misc Ports

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -52,6 +52,7 @@
 #define BLOCK_GAS_SMOKE_EFFECT 0x10 // Blocks the effect that chemical clouds would have on a mob -- glasses, mask and helmets ONLY! (NOTE: flag shared with ONESIZEFITSALL)
 #define FLEXIBLEMATERIAL       0x20 // At the moment, masks with this flag will not prevent eating even if they are covering your face.
 #define PREMODIFIED            0x40 // Gloves that are clipped by default
+#define IS_BELT                0x80 // Items that can be worn on the belt slot, even with no undersuit equipped
 
 // Flags for pass_flags.
 #define PASSTABLE  0x1

--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -32,7 +32,7 @@
 			var/turf/Tr = null
 			for(var/obj/item/weapon/implant/chem/C in world)
 				Tr = get_turf(C)
-				if((Tr) && (Tr.z != src.z))	continue//Out of range
+				if((Tr) && !AreConnectedZLevels(Tr.z, src.z))	continue // Out of range
 				if(!C.implanted) continue
 				dat += "[C.imp_in.name] | Remaining Units: [C.reagents.total_volume] | Inject: "
 				dat += "<A href='?src=\ref[src];inject1=\ref[C]'>(<font color=red>(1)</font>)</A>"
@@ -42,11 +42,11 @@
 			dat += "<HR>Tracking Implants<BR>"
 			for(var/obj/item/weapon/implant/tracking/T in world)
 				Tr = get_turf(T)
-				if((Tr) && (Tr.z != src.z))	continue//Out of range
+				if((Tr) && !AreConnectedZLevels(Tr.z, src.z))	continue // Out of range
 				if(!T.implanted) continue
 				var/loc_display = "Unknown"
 				var/mob/living/carbon/M = T.imp_in
-				if((M.z in GLOB.using_map.station_levels) && !istype(M.loc, /turf/space))
+				if(!istype(M.loc, /turf/space))
 					var/turf/mob_loc = get_turf(M)
 					loc_display = mob_loc.loc
 				if(T.malfunction)

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -172,7 +172,7 @@
 			if(S.dried_type == S.type)
 				S.dry = 1
 				S.name = "dried [S.name]"
-				S.color = "#aaaaaa"
+				S.color = "#a38463"
 				stock_item(S)
 			else
 				var/D = S.dried_type

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -120,8 +120,10 @@
 				if (M.timeofdeath + 6000 < world.time)
 					continue
 			var/turf/T = get_turf(M)
-			if(T)	continue
-			if(T.z == 2)	continue
+			if(!T)
+				continue
+			if(!(T.z in GLOB.using_map.player_levels))
+				continue
 			var/tmpname = M.real_name
 			if(areaindex[tmpname])
 				tmpname = "[tmpname] ([++areaindex[tmpname]])"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -338,7 +338,7 @@ var/list/global/slot_flags_enumeration = list(
 			if( (slot_flags & SLOT_TWOEARS) && H.get_equipped_item(slot_other_ear) )
 				return 0
 		if(slot_belt, slot_wear_id)
-			if(slot == slot_belt && (item_flags & ITEM_FLAG_IS_BELT))
+			if(slot == slot_belt && (item_flags & IS_BELT))
 				return 1
 			else if(!H.w_uniform && (slot_w_uniform in mob_equip))
 				if(!disable_warning)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -337,8 +337,10 @@ var/list/global/slot_flags_enumeration = list(
 				return 0
 			if( (slot_flags & SLOT_TWOEARS) && H.get_equipped_item(slot_other_ear) )
 				return 0
-		if(slot_wear_id, slot_belt)
-			if(!H.w_uniform && (slot_w_uniform in mob_equip))
+		if(slot_belt, slot_wear_id)
+			if(slot == slot_belt && (item_flags & ITEM_FLAG_IS_BELT))
+				return 1
+			else if(!H.w_uniform && (slot_w_uniform in mob_equip))
 				if(!disable_warning)
 					to_chat(H, "<span class='warning'>You need a jumpsuit before you can attach this [name].</span>")
 				return 0

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -5,6 +5,7 @@
 	icon_state = "utilitybelt"
 	item_state = "utility"
 	storage_slots = 7
+	item_flags = IS_BELT
 	max_w_class = ITEM_SIZE_NORMAL
 	slot_flags = SLOT_BELT
 	attack_verb = list("whipped", "lashed", "disciplined")
@@ -187,7 +188,7 @@
 	icon_state = "swatbelt"
 	item_state = "swatbelt"
 	storage_slots = 9
-	
+
 /obj/item/weapon/storage/belt/security/tactical/fed
 	name = "federation combat belt"
 	desc = "Can hold combat gear such as ammo magazines and grenades."

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -63,6 +63,13 @@
 			if(!T.place_handcuffs(H, user))
 				user.unEquip(T)
 				qdel(T)
+		else if(user.zone_sel.selecting == BP_CHEST)
+			if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/space))
+				if(H == user || do_mob(user, H, 10))	//Skip the time-check if patching your own suit, that's handled in attackby()
+					H.wear_suit.attackby(src, user)
+			else
+				to_chat(user, "<span class='warning'>\The [H] isn't wearing a spacesuit for you to reseal.</span>")
+
 		else
 			return ..()
 		return 1

--- a/code/game/objects/items/weapons/towels.dm
+++ b/code/game/objects/items/weapons/towels.dm
@@ -2,6 +2,7 @@
 	name = "towel"
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "towel"
+	item_flags = IS_BELT
 	slot_flags = SLOT_HEAD | SLOT_BELT | SLOT_OCLOTHING
 	force = 3.0
 	w_class = ITEM_SIZE_NORMAL

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -6,6 +6,7 @@
 	var/class = 0                           // Size. Lower is smaller. Uses floating point values!
 	var/descriptor                          // 'gaping hole' etc.
 	var/damtype = BURN                      // Punctured or melted
+	var/patched = 0
 	var/obj/item/clothing/suit/space/holder // Suit containing the list of breaches holding this instance.
 	var/global/list/breach_brute_descriptors = list(
 		"tiny puncture",
@@ -29,9 +30,9 @@
 	var/list/breaches = list()              // Breach datum container.
 	var/resilience = 0.2                    // Multiplier that turns damage into breach class. 1 is 100% of damage to breach, 0.1 is 10%. 0.2 -> 50 brute/burn damage to cause 10 breach damage
 	var/breach_threshold = 3                // Min damage before a breach is possible. Damage is subtracted by this amount, it determines the "hardness" of the suit.
-	var/damage = 0                          // Current total damage
-	var/brute_damage = 0                    // Specifically brute damage.
-	var/burn_damage = 0                     // Specifically burn damage.
+	var/damage = 0                          // Current total damage. Does not count patched breaches.
+	var/brute_damage = 0                    // Specifically brute damage. Includes patched punctures.
+	var/burn_damage = 0                     // Specifically burn damage. Includes patched burns.
 
 /datum/breach/proc/update_descriptor()
 
@@ -42,6 +43,8 @@
 		descriptor = breach_burn_descriptors[class]
 	else if(damtype == BRUTE)
 		descriptor = breach_brute_descriptors[class]
+	if(patched)
+		descriptor = "patched [descriptor]"
 
 //Repair a certain amount of brute or burn damage to the suit.
 /obj/item/clothing/suit/space/proc/repair_breaches(var/damtype, var/amount, var/mob/user)
@@ -89,10 +92,6 @@
 
 	if(damage > 25) return //We don't need to keep tracking it when it's at 250% pressure loss, really.
 
-	if(!loc) return
-	var/turf/T = get_turf(src)
-	if(!T) return
-
 	//Increase existing breaches.
 	for(var/datum/breach/existing in breaches)
 
@@ -111,9 +110,9 @@
 				amount -= needs
 
 			if(existing.damtype == BRUTE)
-				T.visible_message("<span class = 'warning'>\The [existing.descriptor] on [src] gapes wider!</span>")
+				visible_message("<span class = 'warning'>\The [existing.descriptor] on [src] gapes wider[existing.patched ? ", tearing the patch" : ""]!</span>")
 			else if(existing.damtype == BURN)
-				T.visible_message("<span class = 'warning'>\The [existing.descriptor] on [src] widens!</span>")
+				visible_message("<span class = 'warning'>\The [existing.descriptor] on [src] widens[existing.patched ? ", ruining the patch" : ""]!</span>")
 
 	if (amount)
 		//Spawn a new breach.
@@ -127,9 +126,9 @@
 		B.holder = src
 
 		if(B.damtype == BRUTE)
-			T.visible_message("<span class = 'warning'>\A [B.descriptor] opens up on [src]!</span>")
+			visible_message("<span class = 'warning'>\A [B.descriptor] opens up on [src]!</span>")
 		else if(B.damtype == BURN)
-			T.visible_message("<span class = 'warning'>\A [B.descriptor] marks the surface of [src]!</span>")
+			visible_message("<span class = 'warning'>\A [B.descriptor] marks the surface of [src]!</span>")
 
 	calc_breach_damage()
 
@@ -139,6 +138,7 @@
 	damage = 0
 	brute_damage = 0
 	burn_damage = 0
+	var/all_patched = 1
 
 	if(!can_breach || !breaches || !breaches.len)
 		name = initial(name)
@@ -149,7 +149,10 @@
 			src.breaches -= B
 			qdel(B)
 		else
-			damage += B.class
+			if(!B.patched)
+				damage += B.class
+				all_patched = 0
+
 			if(B.damtype == BRUTE)
 				brute_damage += B.class
 			else if(B.damtype == BURN)
@@ -162,6 +165,9 @@
 			name = "scorched [initial(name)]"
 		else
 			name = "damaged [initial(name)]"
+
+	else if(all_patched)
+		name = "patched [initial(name)]"
 	else
 		name = initial(name)
 
@@ -181,7 +187,7 @@
 		if(!repair_power)
 			return
 
-		if(!damage || !burn_damage)
+		if(burn_damage <= 0)
 			to_chat(user, "There is no surface damage on \the [src] to repair.")
 			return
 
@@ -193,7 +199,7 @@
 
 	else if(isWelder(W))
 
-		if (!damage || ! brute_damage)
+		if (brute_damage <= 0)
 			to_chat(user, "There is no structural damage on \the [src] to repair.")
 			return
 
@@ -203,6 +209,23 @@
 			return
 
 		repair_breaches(BRUTE, 3, user)
+		return
+
+	else if(istype(W, /obj/item/weapon/tape_roll))
+		var/datum/breach/target_breach		//Target the largest unpatched breach.
+		for(var/datum/breach/B in breaches)
+			if(B.patched)
+				continue
+			if(!target_breach || (B.class > target_breach.class))
+				target_breach = B
+
+		if(!target_breach)
+			to_chat(user, "There are no open breaches to seal with \the [W].")
+		else if(user != loc || do_after(user, 30, src))		//Doing this in your own inventory is awkward.
+			user.visible_message("<b>[user]</b> uses \the [W] to seal \the [target_breach] on \the [src].")
+			target_breach.patched = 1
+			target_breach.update_descriptor()
+			calc_breach_damage()
 		return
 
 	..()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -437,8 +437,7 @@ meteor_act
 	if(!wear_suit) return
 	if(!istype(wear_suit,/obj/item/clothing/suit/space)) return
 	var/obj/item/clothing/suit/space/SS = wear_suit
-	var/penetrated_dam = max(0,(damage - SS.breach_threshold))
-	if(penetrated_dam) SS.create_breaches(damtype, penetrated_dam)
+	SS.create_breaches(damtype, damage)
 
 /mob/living/carbon/human/reagent_permeability()
 	var/perm = 0

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -88,17 +88,17 @@ proc/getsensorlevel(A)
 
 //The base miss chance for the different defence zones
 var/list/global/base_miss_chance = list(
-	BP_HEAD = 40,
+	BP_HEAD = 50,
 	BP_CHEST = 10,
 	BP_GROIN = 20,
-	BP_L_LEG = 20,
-	BP_R_LEG = 20,
-	BP_L_ARM = 20,
-	BP_R_ARM = 20,
+	BP_L_LEG = 50,
+	BP_R_LEG = 50,
+	BP_L_ARM = 30,
+	BP_R_ARM = 30,
 	BP_L_HAND = 50,
 	BP_R_HAND = 50,
-	BP_L_FOOT = 50,
-	BP_R_FOOT = 50,
+	BP_L_FOOT = 60,
+	BP_R_FOOT = 60,
 )
 
 //Used to weight organs when an organ is hit randomly (i.e. not a directed, aimed attack).

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -7,6 +7,7 @@
 	w_class = ITEM_SIZE_LARGE
 	force = 10
 	one_hand_penalty = 2
+	accuracy = 2
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/item/projectile/beam/midlaser

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -20,7 +20,8 @@
 	one_hand_penalty = 3
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
 	force = 8
-	max_shots = 10
+	max_shots = 12
+	accuracy = 1
 	projectile_type = /obj/item/projectile/beam/stun/heavy
 	wielded_item_state = "tasercarbine-wielded"
 
@@ -47,7 +48,7 @@
 	item_state = "stunrevolver"
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
 	projectile_type = /obj/item/projectile/energy/electrode
-	max_shots = 8
+	max_shots = 6
 
 /obj/item/weapon/gun/energy/stunrevolver/rifle
 	name = "stun rifle"
@@ -59,7 +60,8 @@
 	one_hand_penalty = 6
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
 	force = 10
-	max_shots = 12
+	max_shots = 10
+	accuracy = 1
 	projectile_type = /obj/item/projectile/energy/electrode/stunshot
 	wielded_item_state = "stunrifle-wielded"
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -29,7 +29,7 @@
 	damage = 25
 
 /obj/item/projectile/beam/midlaser
-	damage = 40
+	damage = 50
 	armor_penetration = 10
 
 /obj/item/projectile/beam/heavylaser
@@ -191,7 +191,6 @@
 /obj/item/projectile/beam/stun/heavy
 	name = "heavy stun beam"
 	agony = 60
-	armor_penetration = 10
 
 /obj/item/projectile/beam/stun/shock
 	name = "shock beam"

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -60,15 +60,16 @@
 	fire_sound = 'sound/weapons/Taser.ogg'
 	nodamage = 1
 	taser_effect = 1
-	agony = 40
+	agony = 50
 	damage_type = PAIN
 	//Damage will be handled on the MOB side, to prevent window shattering.
 
 /obj/item/projectile/energy/electrode/stunshot
 	nodamage = 0
-	damage = 10
-	agony = 80
+	damage = 15
+	agony = 70
 	damage_type = BURN
+	armor_penetration = 10
 
 /obj/item/projectile/energy/declone
 	name = "decloner beam"


### PR DESCRIPTION
Ports all the misc stuff on my "To Port" list.

Fixes Tracking Implants so they're Multi-Z Capable
Fixes tracking implants not showing in the target list
Make items dried in the drying rack brownish instead of gray
Duct tape can temporarily reseal spacesuits
Allow wearing of belts even with no jumpsuit
Weapon effect balancing and hit chance balancing

Shamelessly stolen from the following Bay PRs:
https://github.com/Baystation12/Baystation12/pull/19734
https://github.com/Baystation12/Baystation12/pull/19886
https://github.com/Baystation12/Baystation12/pull/20026
https://github.com/Baystation12/Baystation12/pull/20067
https://github.com/Baystation12/Baystation12/pull/20175
https://github.com/Baystation12/Baystation12/pull/20756
https://github.com/Baystation12/Baystation12/pull/20787

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
