### PR TITLE
Reworks Material Grinding

### DIFF
--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -83,6 +83,7 @@ var/list/stack_to_material
 	var/sheet_plural_name = "sheets"
 	var/is_fusion_fuel
 	var/list/gaseous_products	  		  // Used with sublimator to produce gas
+	var/list/chem_products				  // Used with the grinder to produce chemicals
 
 	// Shards/tables/structures
 	var/shard_type = SHARD_SHRAPNEL       // Path of debris object.
@@ -254,6 +255,9 @@ var/list/stack_to_material
 	weight = 22
 	stack_origin_tech = list(TECH_MATERIAL = 5)
 	door_icon_base = "stone"
+	chem_products = list(
+				/datum/reagent/uranium = 15
+				)
 
 /material/diamond
 	name = "diamond"
@@ -281,6 +285,9 @@ var/list/stack_to_material
 	stack_origin_tech = list(TECH_MATERIAL = 4)
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
+	chem_products = list(
+				/datum/reagent/gold = 15
+				)
 
 /material/gold/bronze //placeholder for ashtrays
 	name = "bronze"
@@ -295,6 +302,9 @@ var/list/stack_to_material
 	stack_origin_tech = list(TECH_MATERIAL = 3)
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
+	chem_products = list(
+				/datum/reagent/silver = 15
+				)
 
 /material/phoron
 	name = "phoron"
@@ -311,6 +321,9 @@ var/list/stack_to_material
 	is_fusion_fuel = 1
 	gaseous_products = list(
 				"phoron" = 3.4 // 1360~g / 405g per mole
+				)
+	chem_products = list(
+				/datum/reagent/toxin/phoron = 15
 				)
 
 /material/phoron/supermatter
@@ -354,6 +367,9 @@ var/list/stack_to_material
 	gaseous_products = list(
 				"chlorine" = 10.3 // 600~g / 58.4 per mole
 				)
+	chem_products = list(
+				/datum/reagent/sodiumchloride = 20
+				)
 
 /material/steel
 	name = DEFAULT_WALL_MATERIAL
@@ -363,6 +379,10 @@ var/list/stack_to_material
 	icon_reinf = "metal"
 	icon_colour = "#666666"
 	hitsound = 'sound/weapons/smash.ogg'
+	chem_products = list(
+				/datum/reagent/iron = 15,
+				/datum/reagent/carbon = 5
+				)
 
 /material/diona
 	name = "biomass"
@@ -557,6 +577,9 @@ var/list/stack_to_material
 	created_window = /obj/structure/window/phoronbasic
 	wire_product = null
 	rod_product = /obj/item/stack/material/glass/phoronrglass
+	chem_products = list(
+				/datum/reagent/toxin/phoron = 10
+				)
 
 /material/glass/phoron/reinforced
 	name = "rphglass"
@@ -586,6 +609,9 @@ var/list/stack_to_material
 	melting_point = T0C+371 //assuming heat resistant plastic
 	stack_origin_tech = list(TECH_MATERIAL = 3)
 	conductive = 0
+	chem_products = list(
+				/datum/reagent/toxin/plasticide = 20
+				)
 
 /material/plastic/holographic
 	name = "holoplastic"
@@ -634,6 +660,9 @@ var/list/stack_to_material
 	gaseous_products = list(
 				"hydrogen" = 30 //(30~g / 1 grams per mole) probably don't have a ton of this stuff per stack
 				)
+	chem_products = list(
+				/datum/reagent/hydrazine = 20
+				)
 
 /material/ice
 	name = "ice"
@@ -643,6 +672,10 @@ var/list/stack_to_material
 				"hydrogen" = 22.2, //(600~g / 18 grams per mole)*2/3
 				"oxygen" = 11.1
 				)
+	chem_products = list(
+				/datum/reagent/drink/ice = 15,
+				/datum/reagent/water = 5
+				)
 
 /material/dryice
 	name = "dryice"
@@ -650,6 +683,9 @@ var/list/stack_to_material
 	icon_colour = "#dce2e2"
 	gaseous_products = list(
 				"carbon_dioxide" = 13.6 //(600~g / 44.01 grams per mole)
+				)
+	chem_products = list(
+				/datum/reagent/carbon = 20
 				)
 
 /material/platinum
@@ -669,6 +705,9 @@ var/list/stack_to_material
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
 	hitsound = 'sound/weapons/smash.ogg'
+	chem_products = list(
+				/datum/reagent/iron = 20
+				)
 
 // Adminspawn only, do not let anyone get this.
 /material/voxalloy
@@ -712,6 +751,9 @@ var/list/stack_to_material
 	sheet_plural_name = "planks"
 	hitsound = 'sound/effects/woodhit.ogg'
 	conductive = 0
+	chem_products = list(
+				/datum/reagent/carbon = 10
+				)
 
 /material/wood/holographic
 	name = "holowood"

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -3,8 +3,6 @@
 #define GAS 3
 
 #define BOTTLE_SPRITES list("bottle-1", "bottle-2", "bottle-3", "bottle-4") //list of available bottle sprites
-#define REAGENTS_PER_SHEET 20
-
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -327,16 +325,6 @@
 	var/obj/item/weapon/reagent_containers/beaker = null
 	var/limit = 10
 	var/list/holdingitems = list()
-	var/list/sheet_reagents = list(
-		/obj/item/stack/material/iron = /datum/reagent/iron,
-		/obj/item/stack/material/uranium = /datum/reagent/uranium,
-		/obj/item/stack/material/phoron = /datum/reagent/toxin/phoron,
-		/obj/item/stack/material/phoron/fifty = /datum/reagent/toxin/phoron,
-		/obj/item/stack/material/gold = /datum/reagent/gold,
-		/obj/item/stack/material/silver = /datum/reagent/silver,
-		/obj/item/stack/material/mhydrogen = /datum/reagent/hydrazine,
-		/obj/item/stack/material/salt = /datum/reagent/sodiumchloride
-		)
 
 /obj/machinery/reagentgrinder/New()
 	..()
@@ -411,7 +399,14 @@
 		src.updateUsrDialog()
 		return 0
 
-	if(!sheet_reagents[O.type] && (!O.reagents || !O.reagents.total_volume))
+	if(istype(O,/obj/item/stack/material))
+		var/obj/item/stack/material/stack = O
+		var/material/material = stack.material
+		if(!material.chem_products.len)
+			to_chat(user, "\The [material.name] is unable to produce any usable reagents.")
+			return 1
+
+	if(!O.reagents || !O.reagents.total_volume)
 		to_chat(user, "\The [O] is not suitable for blending.")
 		return 1
 
@@ -543,16 +538,25 @@
 		if(remaining_volume <= 0)
 			break
 
-		if(sheet_reagents[O.type])
-			var/obj/item/stack/stack = O
-			if(istype(stack))
-				var/amount_to_take = max(0,min(stack.amount,round(remaining_volume/REAGENTS_PER_SHEET)))
-				if(amount_to_take)
-					stack.use(amount_to_take)
-					if(QDELETED(stack))
-						holdingitems -= stack
-					beaker.reagents.add_reagent(sheet_reagents[stack.type], (amount_to_take*REAGENTS_PER_SHEET))
-					continue
+		var/obj/item/stack/material/stack = O
+		if(istype(stack))
+			var/material/material = stack.material
+			if(!material.chem_products.len)
+				break
+
+			var/list/chem_products = material.chem_products
+			var/sheet_volume = 0
+			for(var/chem in chem_products)
+				sheet_volume += chem_products[chem]
+
+			var/amount_to_take = max(0,min(stack.amount,round(remaining_volume/sheet_volume)))
+			if(amount_to_take)
+				stack.use(amount_to_take)
+				if(QDELETED(stack))
+					holdingitems -= stack
+				for(var/chem in chem_products)
+					beaker.reagents.add_reagent(chem, (amount_to_take*chem_products[chem]))
+				continue
 
 		if(O.reagents)
 			O.reagents.trans_to(beaker, min(O.reagents.total_volume, remaining_volume))
@@ -562,4 +566,3 @@
 			if (beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
 				break
 
-#undef REAGENTS_PER_SHEET


### PR DESCRIPTION
Materials can now be ground into multiple reagents and can have different amounts of each reagent per sheet.

Kept the old grinding recipes, and also added a few more:
Ice to water and ice
Dry ice to carbon
Iron to iron
Steel to iron and carbon
Plastic to plasticide
Wood to a little carbon
Phoron-glass to a little phoron

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
