### PR TITLE
Makes Time Configurable, Links IC time to realtime

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -823,8 +823,8 @@
 			return global.round_progressing;
 		if("round_start_time")
 			return global.round_start_time;
-		if("roundstart_hour")
-			return global.roundstart_hour;
+		if("roundstart_timeofday")
+			return global.roundstart_timeofday;
 		if("rune_list")
 			return global.rune_list;
 		if("runtime_diary")
@@ -1902,8 +1902,8 @@
 			global.round_progressing=newval;
 		if("round_start_time")
 			global.round_start_time=newval;
-		if("roundstart_hour")
-			global.roundstart_hour=newval;
+		if("roundstart_timeofday")
+			global.roundstart_timeofday=newval;
 		if("rune_list")
 			global.rune_list=newval;
 		if("runtime_diary")
@@ -2569,7 +2569,7 @@
 	"robot_modules",
 	"round_progressing",
 	"round_start_time",
-	"roundstart_hour",
+	"roundstart_timeofday",
 	"rune_list",
 	"runtime_diary",
 	"same_wires",

--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -28,14 +28,14 @@
 
 	return wtime + (time_offset + wusage) * world.tick_lag
 
-var/roundstart_hour
+var/roundstart_timeofday
 var/station_date = ""
 var/next_station_date_change = 1 DAY
 
 #define duration2stationtime(time) time2text(station_time_in_ticks + time, "hh:mm")
-#define worldtime2stationtime(time) time2text(roundstart_hour HOURS + time, "hh:mm")
+#define worldtime2stationtime(time) time2text(roundstart_timeofday + time, "hh:mm")
 #define round_duration_in_ticks (round_start_time ? world.time - round_start_time : 0)
-#define station_time_in_ticks (roundstart_hour HOURS + round_duration_in_ticks)
+#define station_time_in_ticks (roundstart_timeofday + round_duration_in_ticks)
 
 /proc/stationtime2text()
 	return time2text(station_time_in_ticks, "hh:mm")
@@ -48,7 +48,7 @@ var/next_station_date_change = 1 DAY
 	if(!station_date || update_time)
 		var/extra_days = round(station_time_in_ticks / (1 DAY)) DAYS
 		var/timeofday = world.timeofday + extra_days
-		station_date = num2text((text2num(time2text(timeofday, "YYYY"))+544)) + "-" + time2text(timeofday, "MM-DD")
+		station_date = num2text((text2num(time2text(timeofday, "YYYY"))+config.year_skip)) + "-" + time2text(timeofday, "MM-DD")
 	return station_date
 
 /proc/time_stamp()
@@ -92,8 +92,8 @@ var/round_start_time = 0
 	next_duration_update = world.time + 1 MINUTES
 	return last_round_duration
 
-/hook/startup/proc/set_roundstart_hour()
-	roundstart_hour = pick(2,7,12,17)
+/hook/startup/proc/set_roundstart_timeofday()
+	roundstart_timeofday = world.timeofday + (config.time_zone HOURS)
 	return 1
 
 GLOBAL_VAR_INIT(midnight_rollovers, 0)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -202,6 +202,9 @@ var/list/gamemode_cache = list()
 	var/ghosts_can_possess_animals = 0
 	var/delist_when_no_admins = FALSE
 
+	var/year_skip = 420 // How many years we are in the future IC. A multiple of 28 (e.g. 392 or 420) will always give you a calendar that exactly matches the current year.
+	var/time_zone = -5 // The IC time-zone in relation to GMT. EST by default.
+
 	var/allow_map_switching = 0 // Whether map switching is allowed
 	var/auto_map_vote = 0 // Automatically call a map vote at end of round and switch to the selected map
 	var/wait_for_sigusr1_reboot = 0 // Don't allow reboot unless it was caused by SIGUSR1
@@ -688,6 +691,11 @@ var/list/gamemode_cache = list()
 
 				if("delist_when_no_admins")
 					config.delist_when_no_admins = TRUE
+
+				if("year_skip")
+					config.year_skip = text2num(value)
+				if("time_zone")
+					config.time_zone = text2num(value)
 
 				if("map_switching")
 					config.allow_map_switching = 1

--- a/code/game/gamemodes/events/holidays/Holidays.dm
+++ b/code/game/gamemodes/events/holidays/Holidays.dm
@@ -89,6 +89,7 @@ var/global/Holiday = null
 
 		if(10)	//Oct
 			switch(DD)
+				if(3)							Holiday = "German Unity Day"
 				if(4)							Holiday = "Animal's Day"
 				if(7)							Holiday = "Smiling Day"
 				if(16)							Holiday = "Boss' Day"
@@ -105,7 +106,6 @@ var/global/Holiday = null
 			switch(DD)
 				if(10)							Holiday = "Human-Rights Day"
 				if(14)							Holiday = "Monkey Day"
-				if(21)							if(YY==12)	Holiday = "End of the World"
 				if(22)							Holiday = "Orgasming Day"		//lol. These all actually exist
 				if(24)							Holiday = "Christmas Eve"
 				if(25)							Holiday = "Christmas"

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -370,6 +370,12 @@ STARLIGHT 0
 ## Uncomment this line to announce shuttle dock announcements to the main IRC channel, if MAIN_IRC has also been setup.
 # ANNOUNCE_SHUTTLE_DOCK_TO_IRC
 
+## Uncomment to change the in-game year as the number of years from the current real year
+# YEAR_SKIP 420
+
+## Uncomment to change the in-game timezone relative to GMT
+# TIME_ZONE -5
+
 ## Uncomment to enable map voting; you'll need to use the script at tools/server.sh or an equivalent for it to take effect
 ## You'll also likely need to enable WAIT_FOR_SIGUSR1 below
 # MAP_SWITCHING

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -240,7 +240,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python tools/GenerateGlobalVarAccess/gen_globals.py persistentss13.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< '45f15a1aff42863fbc8fe3ad1fd9d026 *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< 'dfb0e63d9cc1d9122f49acb5242deba7 *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH persistentss13.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon persistentss13.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
Year skip and Timezone are config options. Roundstart time is now equal to the current time GMT +- timezone hours. 

Year skip default has been set to 420 years, down from baycode's 544, and up from our lore's 400. It's 420 because that syncs up perfectly with the Gregorian calendar's cycle, so the calendar will be exactly the same as the real current year's.

Timezone default has been set to EST (GMT-5) because /shrug

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
