### PR TITLE
Reworks Autolathe, Adds Autolathe Recipe Tests to Travis

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -773,6 +773,10 @@
 			return global.prometheans;
 		if("protected_objects")
 			return global.protected_objects;
+		if("protolathe_categories")
+			return global.protolathe_categories;
+		if("protolathe_recipes")
+			return global.protolathe_recipes;
 		if("rad_collectors")
 			return global.rad_collectors;
 		if("radiation_repository")
@@ -1850,6 +1854,10 @@
 			global.prometheans=newval;
 		if("protected_objects")
 			global.protected_objects=newval;
+		if("protolathe_categories")
+			global.protolathe_categories=newval;
+		if("protolathe_recipes")
+			global.protolathe_recipes=newval;
 		if("rad_collectors")
 			global.rad_collectors=newval;
 		if("radiation_repository")
@@ -2540,6 +2548,8 @@
 	"processing_turfs",
 	"prometheans",
 	"protected_objects",
+	"protolathe_categories",
+	"protolathe_recipes",
 	"rad_collectors",
 	"radiation_repository",
 	"radio_controller",

--- a/code/datums/supplypacks/materials.dm
+++ b/code/datums/supplypacks/materials.dm
@@ -14,6 +14,12 @@
 	cost = 40
 	containername = "\improper Bulk Glass Shipment"
 
+/decl/hierarchy/supply_pack/materials/copper200
+	name = "Bulk Copper Order - 200"
+	contains = list(/obj/item/stack/material/copper/fifty = 4)
+	cost = 40
+	containername = "\improper Copper sheets crate"
+
 // Material sheets (50 - full stack)
 /decl/hierarchy/supply_pack/materials/steel50
 	name = "Steel (x50)"
@@ -26,6 +32,12 @@
 	contains = list(/obj/item/stack/material/glass/fifty)
 	cost = 10
 	containername = "\improper Glass sheets crate"
+
+/decl/hierarchy/supply_pack/materials/copper50
+	name = "Copper (x50)"
+	contains = list(/obj/item/stack/material/copper/fifty)
+	cost = 10
+	containername = "\improper Copper sheets crate"
 
 /decl/hierarchy/supply_pack/materials/wood50
 	name = "Wooden Planks (x50)"

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -1,6 +1,6 @@
 /obj/machinery/autolathe
 	name = "autolathe"
-	desc = "It produces items using metal and glass."
+	desc = "It produces items using sheets of materials."
 	icon_state = "autolathe"
 	density = 1
 	anchored = 1
@@ -11,8 +11,8 @@
 	clickvol = 30
 
 	var/list/machine_recipes
-	var/list/stored_material =  list(DEFAULT_WALL_MATERIAL = 0, "glass" = 0)
-	var/list/storage_capacity = list(DEFAULT_WALL_MATERIAL = 0, "glass" = 0)
+	var/list/stored_material =  list(DEFAULT_WALL_MATERIAL = 0)
+	var/list/storage_capacity = 0
 	var/show_category = "All"
 
 	var/hacked = 0
@@ -24,7 +24,6 @@
 	var/build_time = 50
 
 	var/datum/wires/autolathe/wires = null
-
 
 /obj/machinery/autolathe/New()
 
@@ -49,6 +48,43 @@
 	if(!machine_recipes)
 		machine_recipes = autolathe_recipes
 
+/obj/machinery/autolathe/proc/handle_recipe(var/datum/autolathe/recipe/R, var/index = 0)
+	if(R.hidden && !hacked || (show_category != "All" && show_category != R.category))
+		return "" // Returns an emtpy string to avoid concat issues below
+	var/can_make = 1
+	var/material_string = ""
+	var/multiplier_string = ""
+	var/max_sheets
+	var/comma
+	if(!R.resources || !R.resources.len)
+		material_string = "No resources required.</td>"
+	else
+		//Make sure it's buildable and list requires resources.
+		for(var/material in R.resources)
+			var/sheets = round(stored_material[material]/round(R.resources[material]*mat_efficiency))
+			if(isnull(max_sheets) || max_sheets > sheets)
+				max_sheets = sheets
+			if(!isnull(stored_material[material]) && stored_material[material] < round(R.resources[material]*mat_efficiency))
+				can_make = 0
+			if(!comma)
+				comma = 1
+			else
+				material_string += ", "
+			material_string += "[round(R.resources[material] * mat_efficiency)] [material]"
+		material_string += ".<br></td>"
+		//Build list of multipliers for sheets.
+		if(R.is_stack)
+			var/obj/item/stack/R_stack = R.path
+			max_sheets = min(max_sheets, initial(R_stack.max_amount))
+			//do not allow lathe to print more sheets than the max amount that can fit in one stack
+			if(max_sheets && max_sheets > 0)
+				multiplier_string  += "<br>"
+				for(var/i = 5;i<max_sheets;i*=2) //5,10,20,40...
+					multiplier_string  += "<a href='?src=\ref[src];make=[index];multiplier=[i]'>\[x[i]\]</a>"
+				multiplier_string += "<a href='?src=\ref[src];make=[index];multiplier=[max_sheets]'>\[x[max_sheets]\]</a>"
+
+	return "<tr><td width = 180>[R.hidden ? "<font color = 'red'>*</font>" : ""]<b>[can_make ? "<a href='?src=\ref[src];make=[index];multiplier=1'>" : ""][R.name][can_make ? "</a>" : ""]</b>[R.hidden ? "<font color = 'red'>*</font>" : ""][multiplier_string]</td><td align = right>[material_string]</tr>"
+
 /obj/machinery/autolathe/interact(mob/user as mob)
 
 	update_recipe_list()
@@ -68,8 +104,23 @@
 		var/material_bottom = "<tr>"
 
 		for(var/material in stored_material)
+			if(stored_material[material] == 0)
+				continue
+
+			if(!machine_recipes[material])
+				var/material/material_path = get_material_by_name(material)
+				if(!material_path || !material_path.stack_type)
+					continue
+
+				var/datum/autolathe/recipe/R = new /datum/autolathe/recipe
+				R.name = material
+				R.path = material_path.stack_type
+				R.category = "General"
+				R.is_stack = 1
+				machine_recipes[material] = R
+
 			material_top += "<td width = '25%' align = center><b>[material]</b></td>"
-			material_bottom += "<td width = '25%' align = center>[stored_material[material]]<b>/[storage_capacity[material]]</b></td>"
+			material_bottom += "<td width = '25%' align = center>[stored_material[material]]<b>/[storage_capacity]</b></td>"
 
 		dat += "[material_top]</tr>[material_bottom]</tr></table><hr>"
 		dat += "<h2>Printable Designs</h2><h3>Showing: <a href='?src=\ref[src];change_category=1'>[show_category]</a>.</h3></center><table width = '100%'>"
@@ -77,41 +128,7 @@
 		var/index = 0
 		for(var/datum/autolathe/recipe/R in machine_recipes)
 			index++
-			if(R.hidden && !hacked || (show_category != "All" && show_category != R.category))
-				continue
-			var/can_make = 1
-			var/material_string = ""
-			var/multiplier_string = ""
-			var/max_sheets
-			var/comma
-			if(!R.resources || !R.resources.len)
-				material_string = "No resources required.</td>"
-			else
-				//Make sure it's buildable and list requires resources.
-				for(var/material in R.resources)
-					var/sheets = round(stored_material[material]/round(R.resources[material]*mat_efficiency))
-					if(isnull(max_sheets) || max_sheets > sheets)
-						max_sheets = sheets
-					if(!isnull(stored_material[material]) && stored_material[material] < round(R.resources[material]*mat_efficiency))
-						can_make = 0
-					if(!comma)
-						comma = 1
-					else
-						material_string += ", "
-					material_string += "[round(R.resources[material] * mat_efficiency)] [material]"
-				material_string += ".<br></td>"
-				//Build list of multipliers for sheets.
-				if(R.is_stack)
-					var/obj/item/stack/R_stack = R.path
-					max_sheets = min(max_sheets, initial(R_stack.max_amount))
-					//do not allow lathe to print more sheets than the max amount that can fit in one stack
-					if(max_sheets && max_sheets > 0)
-						multiplier_string  += "<br>"
-						for(var/i = 5;i<max_sheets;i*=2) //5,10,20,40...
-							multiplier_string  += "<a href='?src=\ref[src];make=[index];multiplier=[i]'>\[x[i]\]</a>"
-						multiplier_string += "<a href='?src=\ref[src];make=[index];multiplier=[max_sheets]'>\[x[max_sheets]\]</a>"
-
-			dat += "<tr><td width = 180>[R.hidden ? "<font color = 'red'>*</font>" : ""]<b>[can_make ? "<a href='?src=\ref[src];make=[index];multiplier=1'>" : ""][R.name][can_make ? "</a>" : ""]</b>[R.hidden ? "<font color = 'red'>*</font>" : ""][multiplier_string]</td><td align = right>[material_string]</tr>"
+			dat += handle_recipe(R,index)
 
 		dat += "</table><hr>"
 	//Hacking.
@@ -165,10 +182,13 @@
 
 	for(var/material in eating.matter)
 
-		if(isnull(stored_material[material]) || isnull(storage_capacity[material]))
+		if(isnull(storage_capacity))
 			continue
 
-		if(stored_material[material] >= storage_capacity[material])
+		if(isnull(stored_material[material]))
+			stored_material[material] = 0
+
+		if(stored_material[material] >= storage_capacity)
 			continue
 
 		var/total_material = eating.matter[material]
@@ -178,15 +198,15 @@
 			var/obj/item/stack/stack = eating
 			total_material *= stack.get_amount()
 
-		if(stored_material[material] + total_material > storage_capacity[material])
-			total_material = storage_capacity[material] - stored_material[material]
+		if(stored_material[material] + total_material > storage_capacity)
+			total_material = storage_capacity - stored_material
 			filltype = 1
 		else
 			filltype = 2
 
-		stored_material[material] += total_material
+		stored_material += total_material
 		total_used += total_material
-		mass_per_sheet += eating.matter[material]
+		mass_per_sheet += eating.matter
 
 	if(!filltype)
 		to_chat(user, "<span class='notice'>\The [src] is full. Please remove material from the autolathe in order to insert more.</span>")
@@ -293,8 +313,7 @@
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
 		man_rating += M.rating
 
-	storage_capacity[DEFAULT_WALL_MATERIAL] = mb_rating  * 25000
-	storage_capacity["glass"] = mb_rating  * 12500
+	storage_capacity = mb_rating  * 25000
 	build_time = 50 / man_rating
 	mat_efficiency = 1.1 - man_rating * 0.1// Normally, price is 1.25 the amount of material, so this shouldn't go higher than 0.8. Maximum rating of parts is 3
 

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -1,3 +1,8 @@
+#ifdef T_BOARD_LATHE
+#error T_BOARD_LATHE already defined elsewhere, we can't use it.
+#endif
+#define T_BOARD_LATHE(name)	"circuit board (" + (name) + ")"
+
 /var/global/list/autolathe_recipes
 /var/global/list/autolathe_categories
 
@@ -173,12 +178,6 @@ var/const/EXTRA_COST_FACTOR = 1.25
 /datum/autolathe/recipe/metal
 	name = "steel sheets"
 	path = /obj/item/stack/material/steel
-	category = "General"
-	is_stack = 1
-
-/datum/autolathe/recipe/glass
-	name = "glass sheets"
-	path = /obj/item/stack/material/glass
 	category = "General"
 	is_stack = 1
 
@@ -375,6 +374,32 @@ var/const/EXTRA_COST_FACTOR = 1.25
 	path = /obj/item/stack/cable_coil/single
 	category = "Devices and Components"
 	is_stack = 1
+
+// Only level one stock parts are available, better parts require research
+/datum/autolathe/recipe/matter_bin
+	name = "matter bin"
+	path = /obj/item/weapon/stock_parts/matter_bin
+	category = "Devices and Components"
+
+/datum/autolathe/recipe/manipulator
+	name = "manipulator" // insert ex-gf joke
+	path = /obj/item/weapon/stock_parts/manipulator
+	category = "Devices and Components"
+
+/datum/autolathe/recipe/capacitor
+	name = "capacitor"
+	path = /obj/item/weapon/stock_parts/capacitor
+	category = "Devices and Components"
+
+/datum/autolathe/recipe/scanning_module
+	name = "scanning module"
+	path = /obj/item/weapon/stock_parts/scanning_module
+	category = "Devices and Components"
+
+/datum/autolathe/recipe/micro_laser
+	name = "micro-laser"
+	path = /obj/item/weapon/stock_parts/micro_laser
+	category = "Devices and Components"
 
 /datum/autolathe/recipe/tube/large
 	name = "spotlight tube"
@@ -578,6 +603,22 @@ var/const/EXTRA_COST_FACTOR = 1.25
 	hidden = 1
 	category = "Tools"
 
+/datum/autolathe/recipe/spade
+	name = "spade"
+	path = /obj/item/weapon/shovel/spade
+	category = "Tools"
+
+/datum/autolathe/recipe/shovel
+	name = "shovel"
+	path = /obj/item/weapon/shovel
+	category = "Tools"
+	hidden = 1
+
+/datum/autolathe/recipe/pickaxe
+	name = "mining drill"
+	path = /obj/item/weapon/pickaxe
+	category = "Tools"
+
 /datum/autolathe/recipe/handcuffs
 	name = "handcuffs"
 	path = /obj/item/weapon/handcuffs
@@ -768,3 +809,194 @@ var/const/EXTRA_COST_FACTOR = 1.25
 
 /datum/autolathe/recipe/drinkingglass/wine
 	path = /obj/item/weapon/reagent_containers/food/drinks/glass2/wine
+
+/**************************\
+|      CIRCUIT BOARDS      |
+\**************************/
+
+// These circuits should be enough to help get your station up and running until you have R&D
+/datum/autolathe/recipe/circuitboard_autolathe
+	name = T_BOARD_LATHE("autolathe") // The machines! They're multiplying!
+	path = /obj/item/weapon/circuitboard/autolathe
+	category = "Circuits"
+
+// You need these things to create an R&D department so you can make more advanced stuff
+/datum/autolathe/recipe/circuitboard_destructive_analyzer
+	name = T_BOARD_LATHE("destructive analyzer")
+	path = /obj/item/weapon/circuitboard/destructive_analyzer
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_protolathe
+	name = T_BOARD_LATHE("protolathe")
+	path = /obj/item/weapon/circuitboard/protolathe
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_circuit_imprinter
+	name = T_BOARD_LATHE("circuit imprinter")
+	path = /obj/item/weapon/circuitboard/circuit_imprinter
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_rdserver
+	name = T_BOARD_LATHE("R&D server")
+	path = /obj/item/weapon/circuitboard/rdserver
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_rdconsole
+	name = T_BOARD_LATHE("R&D control console")
+	path = /obj/item/weapon/circuitboard/rdconsole
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_integrated_printer
+	name = "Circuit board (Integrated Circuit Printer)"
+	path = /obj/item/weapon/circuitboard/integrated_printer
+	category = "Circuits"
+	hidden = 1
+
+// Mining machines are basically required for everything
+/datum/autolathe/recipe/circuitboard_miningdrill
+	name = T_BOARD_LATHE("mining drill head")
+	path = /obj/item/weapon/circuitboard/miningdrill
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_miningdrillbrace
+	name = T_BOARD_LATHE("mining drill brace")
+	path = /obj/item/weapon/circuitboard/miningdrillbrace
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_processing_unit_console
+	name = T_BOARD_LATHE("Material Processor Console")
+	path = /obj/item/weapon/circuitboard/processing_unit_console
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_processing_unit
+	name = T_BOARD_LATHE("Material Processor")
+	path = /obj/item/weapon/circuitboard/processing_unit
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_processing_unit
+	name = T_BOARD_LATHE("Material Processor")
+	path = /obj/item/weapon/circuitboard/processing_unit
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_stacking_unit_console
+	name = T_BOARD_LATHE("Stacking Machine Console")
+	path = /obj/item/weapon/circuitboard/stacking_unit_console
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_stacking_machine
+	name = T_BOARD_LATHE("Stacking Machine")
+	path = /obj/item/weapon/circuitboard/stacking_machine
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_unloading_machine
+	name = T_BOARD_LATHE("Unloading Machine")
+	path = /obj/item/weapon/circuitboard/unloading_machine
+	category = "Circuits"
+
+// Botany
+/datum/autolathe/recipe/circuitboard_biogenerator
+	name = T_BOARD_LATHE("biogenerator")
+	path = /obj/item/weapon/circuitboard/biogenerator
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_seed_extractor
+	name = T_BOARD_LATHE("Seed Extractor")
+	path = /obj/item/weapon/circuitboard/seed_extractor
+	category = "Circuits"
+
+// Station Essentials
+// Man should have the freedom to make his own bed, and then lie in it
+/datum/autolathe/recipe/circuitboard_cryopod
+	name = T_BOARD_LATHE("Cryogenic Freezer")
+	path = /obj/item/weapon/circuitboard/cryopod
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_atm
+	name = T_BOARD_LATHE("ATM")
+	path = /obj/item/weapon/circuitboard/atm
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_shuttleengine
+	name = T_BOARD_LATHE("shuttle engine")
+	path = /obj/item/weapon/circuitboard/shuttleengine
+	category = "Circuits"
+	hidden = 1
+
+/datum/autolathe/recipe/circuitboard_solar_control
+	name = T_BOARD_LATHE("solar control console")
+	path = /obj/item/weapon/circuitboard/solar_control
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_recycler
+	name = T_BOARD_LATHE("Recycler")
+	path = /obj/item/weapon/circuitboard/recycler
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_telepad
+	name = T_BOARD_LATHE("Telepad")
+	path = /obj/item/weapon/circuitboard/telepad
+	category = "Circuits"
+
+// Kitchen Stuff
+// Only the most advanced and wealthy stations have more than a microwave
+// They're like college students
+/datum/autolathe/recipe/circuitboard_microwave
+	name = "circuit board (Microwave)"
+	path = /obj/item/weapon/circuitboard/microwave
+	category = "Circuits"
+
+// You can recharge mechs, but not build them. Mostly just so people can recharge their pods at shitty stations
+/datum/autolathe/recipe/circuitboard_mech_recharger
+	name = T_BOARD_LATHE("mech recharger")
+	path = /obj/item/weapon/circuitboard/mech_recharger
+	category = "Circuits"
+
+// Medical Stuff
+// No advanced machines, but enough to keep your patients from dropping dead
+/datum/autolathe/recipe/circuitboard_sleeper
+	name = T_BOARD_LATHE("Sleeper")
+	path = /obj/item/weapon/circuitboard/sleeper
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_chem_dispenser
+	name = T_BOARD_LATHE("Portable Chem Dispenser")
+	path = /obj/item/weapon/circuitboard/chem_dispenser
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_chem_master
+	name = T_BOARD_LATHE("Chem Master 2999")
+	path = /obj/item/weapon/circuitboard/chem_master
+	category = "Circuits"
+
+// Engineering Stuff
+/datum/autolathe/recipe/circuitboard_pacman
+	name = T_BOARD_LATHE("PACMAN-type generator")
+	path = /obj/item/weapon/circuitboard/pacman
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_pacman_super
+	name = T_BOARD_LATHE("SUPERPACMAN-type generator")
+	path = /obj/item/weapon/circuitboard/pacman/super
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_pacman_super_potato
+	name = T_BOARD_LATHE("PTTO-3 nuclear generator")
+	path = /obj/item/weapon/circuitboard/pacman/super/potato
+	category = "Circuits"
+	hidden = 1 // This outputs radiation, so may want to keep it hidden
+
+/datum/autolathe/recipe/circuitboard_pacman_mrs
+	name = T_BOARD_LATHE("MRSPACMAN-type generator")
+	path = /obj/item/weapon/circuitboard/pacman/mrs
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_batteryrack
+	name = T_BOARD_LATHE("battery rack PSU")
+	path = /obj/item/weapon/circuitboard/batteryrack
+	category = "Circuits"
+
+/datum/autolathe/recipe/circuitboard_cell_charger
+	name = T_BOARD_LATHE("Cell Charger")
+	path = /obj/item/weapon/circuitboard/machinery/cell_charger
+	category = "Circuits"
+

--- a/code/game/objects/items/weapons/circuitboards/broken.dm
+++ b/code/game/objects/items/weapons/circuitboards/broken.dm
@@ -4,3 +4,4 @@
 	icon_state = "door_electronics_smoked"
 	origin_tech = null
 	board_type = "other"
+	matter = list("copper" = 50, "glass" = 100)

--- a/code/game/objects/items/weapons/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/weapons/circuitboards/circuitboard.dm
@@ -18,6 +18,7 @@
 	throwforce = 5.0
 	throw_speed = 3
 	throw_range = 15
+	matter = list("copper" = 100, "glass" = 150)
 	var/build_path = null
 	var/board_type = "computer"
 	var/list/req_components = null

--- a/code/game/objects/items/weapons/circuitboards/machinery/cargo.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/cargo.dm
@@ -10,11 +10,13 @@
 	req_components = list(
 		/obj/item/weapon/stock_parts/matter_bin = 1,
 		/obj/item/weapon/stock_parts/manipulator = 1)
+
 /obj/item/weapon/circuitboard/telepad
 	name = T_BOARD("Telepad")
 	build_path = /obj/machinery/telepad_cargo
 	board_type = "machine"
 	origin_tech = "bluespace=1"
+	matter = list("platinum" = 50, "glass" = 150)
 	req_components = list(
 		/obj/item/weapon/stock_parts/matter_bin = 1,
 		/obj/item/weapon/stock_parts/manipulator = 1,

--- a/code/game/objects/items/weapons/circuitboards/machinery/cloning.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/cloning.dm
@@ -12,6 +12,7 @@
 							/obj/item/weapon/stock_parts/scanning_module = 1,
 							/obj/item/weapon/stock_parts/manipulator = 3,
 							/obj/item/weapon/stock_parts/console_screen = 1)
+
 /obj/item/weapon/circuitboard/bioprinter
 	name = T_BOARD("bioprinter")
 	build_path = /obj/machinery/organ_printer/flesh

--- a/code/game/objects/items/weapons/circuitboards/machinery/cryopod.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/cryopod.dm
@@ -7,6 +7,7 @@
 	build_path = /obj/machinery/cryopod
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2)
+	matter = list("gold" = 100, "glass" = 150)
 	req_components = list(
 							/obj/item/weapon/stock_parts/matter_bin = 1,
 							/obj/item/weapon/stock_parts/scanning_module = 1,

--- a/code/game/objects/items/weapons/circuitboards/machinery/mech_recharger.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/mech_recharger.dm
@@ -7,6 +7,7 @@
 	build_path = /obj/machinery/mech_recharger
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 2, TECH_POWER = 2, TECH_ENGINEERING = 2)
+	matter = list("gold" = 50, "glass" = 150)
 	req_components = list(
 							/obj/item/weapon/stock_parts/capacitor = 2,
 							/obj/item/weapon/stock_parts/scanning_module = 1,

--- a/code/game/objects/items/weapons/circuitboards/machinery/pacman.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/pacman.dm
@@ -17,13 +17,16 @@
 	name = T_BOARD("SUPERPACMAN-type generator")
 	build_path = /obj/machinery/power/port_gen/pacman/super
 	origin_tech = list(TECH_DATA = 3, TECH_POWER = 4, TECH_ENGINEERING = 4)
+	matter = list("silver" = 100, "glass" = 150)
 
 /obj/item/weapon/circuitboard/pacman/super/potato
 	name = T_BOARD("PTTO-3 nuclear generator")
 	build_path = /obj/machinery/power/port_gen/pacman/super/potato
 	origin_tech = list(TECH_DATA = 3, TECH_POWER = 5, TECH_ENGINEERING = 4)
+	matter = list("gold" = 100, "glass" = 150)
 
 /obj/item/weapon/circuitboard/pacman/mrs
 	name = T_BOARD("MRSPACMAN-type generator")
 	build_path = /obj/machinery/power/port_gen/pacman/mrs
 	origin_tech = list(TECH_DATA = 3, TECH_POWER = 5, TECH_ENGINEERING = 5)
+	matter = list("platinum" = 100, "glass" = 150)

--- a/code/game/objects/items/weapons/circuitboards/machinery/power.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/power.dm
@@ -26,6 +26,7 @@
 							/obj/item/stack/cable_coil = 30,
 							/obj/item/weapon/stock_parts/capacitor = 1,
 							/obj/item/stack/material/plasteel = 10)
+
 /obj/item/weapon/circuitboard/compressor
 	name = T_BOARD("compressor")
 	build_path = /obj/machinery/compressor
@@ -35,6 +36,7 @@
 							/obj/item/stack/cable_coil = 30,
 							/obj/item/pipe = 2,
 							/obj/item/stack/material/ocp = 10)
+
 /obj/item/weapon/circuitboard/pipeturbine
 	name = T_BOARD("pipe turbine")
 	build_path = /obj/machinery/atmospherics/pipeturbine
@@ -44,6 +46,7 @@
 							/obj/item/stack/cable_coil = 30,
 							/obj/item/pipe = 2,
 							/obj/item/stack/material/plasteel = 10)
+
 /obj/item/weapon/circuitboard/turbinemotor
 	name = T_BOARD("electric motor")
 	build_path = /obj/machinery/power/turbinemotor
@@ -53,6 +56,7 @@
 							/obj/item/stack/cable_coil = 30,
 							/obj/item/weapon/stock_parts/capacitor = 2,
 							/obj/item/stack/material/ocp = 10)
+
 /obj/item/weapon/circuitboard/generator
 	name = T_BOARD("thermoelectric generator")
 	build_path = /obj/machinery/power/generator
@@ -62,6 +66,7 @@
 							/obj/item/stack/cable_coil = 30,
 							/obj/item/weapon/stock_parts/capacitor = 2,
 							/obj/item/stack/material/ocp = 10)
+
 /obj/item/weapon/circuitboard/circulator
 	name = T_BOARD("circulator")
 	build_path = /obj/machinery/atmospherics/binary/circulator

--- a/code/game/objects/items/weapons/circuitboards/machinery/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/research.dm
@@ -7,6 +7,7 @@ obj/item/weapon/circuitboard/rdserver
 	build_path = /obj/machinery/r_n_d/server
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 3)
+	matter = list("gold" = 50, "glass" = 150)
 	req_components = list(
 							/obj/item/stack/cable_coil = 2,
 							/obj/item/weapon/stock_parts/scanning_module = 1)
@@ -16,6 +17,7 @@ obj/item/weapon/circuitboard/rdserver
 	build_path = /obj/machinery/r_n_d/destructive_analyzer
 	board_type = "machine"
 	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2, TECH_DATA = 2)
+	matter = list("gold" = 50, "glass" = 150)
 	req_components = list(
 							/obj/item/weapon/stock_parts/scanning_module = 1,
 							/obj/item/weapon/stock_parts/manipulator = 1,
@@ -36,6 +38,7 @@ obj/item/weapon/circuitboard/rdserver
 	build_path = /obj/machinery/r_n_d/protolathe
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2)
+	matter = list("gold" = 50, "glass" = 150)
 	req_components = list(
 							/obj/item/weapon/stock_parts/matter_bin = 2,
 							/obj/item/weapon/stock_parts/manipulator = 2,
@@ -47,6 +50,7 @@ obj/item/weapon/circuitboard/rdserver
 	build_path = /obj/machinery/r_n_d/circuit_imprinter
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2)
+	matter = list("gold" = 50, "glass" = 150)
 	req_components = list(
 							/obj/item/weapon/stock_parts/matter_bin = 1,
 							/obj/item/weapon/stock_parts/manipulator = 1,
@@ -76,6 +80,7 @@ obj/item/weapon/circuitboard/rdserver
 	build_path = /obj/machinery/integrated_circuit_printer
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2)
+	matter = list("gold" = 100, "glass" = 150)
 	req_components = list(
 						/obj/item/weapon/stock_parts/matter_bin = 1,
 						/obj/item/weapon/stock_parts/manipulator = 1,

--- a/code/game/objects/items/weapons/circuitboards/other.dm
+++ b/code/game/objects/items/weapons/circuitboards/other.dm
@@ -169,6 +169,7 @@
 	build_path = /obj/machinery/shuttleengine
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_POWER = 4)
+	matter = list("platinum" = 100, "glass" = 150)
 	req_components = list(
 							/obj/item/stack/cable_coil = 30,
 							/obj/item/device/assembly/igniter = 1,

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -186,6 +186,9 @@
 /obj/item/stack/material/copper/ten
 	amount = 10
 
+/obj/item/stack/material/copper/fifty
+	amount = 50
+
 /obj/item/stack/material/bronze
 	name = "bronze"
 	icon_state = "sheet-silver"

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -140,7 +140,7 @@
 	item_state = "shovel"
 	w_class = ITEM_SIZE_HUGE
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 50)
+	matter = list(DEFAULT_WALL_MATERIAL = 100)
 	attack_verb = list("bashed", "bludgeoned", "thrashed", "whacked")
 	sharp = 0
 	edge = 1
@@ -152,6 +152,7 @@
 	item_state = "spade"
 	force = 5.0
 	throwforce = 7.0
+	matter = list(DEFAULT_WALL_MATERIAL = 50)
 	w_class = ITEM_SIZE_SMALL
 
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -485,7 +485,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	w_class = ITEM_SIZE_NORMAL
 	throw_speed = 2
 	throw_range = 5
-	matter = list("copper" = 20)
+	matter = list("copper" = 50)
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	item_state = "coil"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -18,6 +18,28 @@ other types of metals and chemistry for reagents).
 */
 //Note: More then one of these can be added to a design.
 
+/var/global/list/protolathe_recipes
+/var/global/list/protolathe_categories
+
+// Items are more expensive to produce than they are to recycle.
+
+/proc/populate_protolathe_recipes()
+
+	//Create global protolathe recipe list if it hasn't been made already.
+	protolathe_recipes = list()
+	protolathe_categories = list()
+	for(var/R in typesof(/datum/design/item)-/datum/design/item)
+		var/datum/design/item/recipe = new R
+		protolathe_recipes += recipe
+		protolathe_categories |= recipe.category
+
+		var/obj/item/I = new recipe.build_path
+		if(I.matter && !recipe.materials) //This can be overidden in the datums.
+			recipe.materials = list()
+			for(var/material in I.matter)
+				recipe.materials[material] = I.matter[material] * EXTRA_COST_FACTOR
+		qdel(I)
+
 /datum/design						//Datum for object designs, used in construction
 	var/name = null					//Name of the created object. If null it will be 'guessed' from build_path if possible.
 	var/desc = null					//Description of the created object. If null it will use group_desc and name where applicable.
@@ -2024,7 +2046,7 @@ CIRCUITS BELOW
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3, TECH_BLUESPACE = 2)
 	build_path = /obj/item/weapon/circuitboard/telecomms/receiver
 	sort_string = "PAAAG"
-	
+
 /datum/design/circuit/bluespace_satellite
 	name = "bluespace satellite"
 	id = "bluespace-satellite"

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -24,7 +24,7 @@
 	w_class = ITEM_SIZE_SMALL
 	var/rating = 1
 
-//Rank 1
+//Rank 1 - Autolathable
 
 /obj/item/weapon/stock_parts/console_screen
 	name = "console screen"

--- a/code/unit_tests/autolathe_tests.dm
+++ b/code/unit_tests/autolathe_tests.dm
@@ -1,0 +1,95 @@
+/*
+	Unit tests for AUTOLATHE recipes
+*/
+/datum/unit_test/autolathe_recipe_test
+	name = "AUTOLATHE: recipe test"
+
+/datum/unit_test/autolathe_recipe_test/start_test()
+	var/bad_tests = 0
+
+	for(var/datum/autolathe/recipe/R in autolathe_recipes)
+		var/failures = 0
+
+		if(!ispath(R.path))
+			failures++
+			log_bad("[R.name] - does not have a path.")
+
+		if(!R.category)
+			failures++
+			log_bad("[R.name] - does not have a category.")
+
+		var/obj/item/stack/I = new R.path
+		if(istype(I) && !R.is_stack)
+			log_debug("[R.name] - is a recipe for a stack-type item, but is not defined as a stack.")
+		qdel(I)
+
+		if(failures > 0)
+			bad_tests++
+
+	if(bad_tests)
+		fail("[bad_tests] autolathe recipe\s were missing either a path or category.")
+	else
+		pass("All autolathe recipes contained a correct path and category.")
+
+	return 1
+
+/datum/unit_test/autolathe_matter_test
+	name = "AUTOLATHE: matter test"
+
+/datum/unit_test/autolathe_matter_test/start_test()
+	var/bad_tests = 0
+
+	for(var/datum/autolathe/recipe/R in autolathe_recipes)
+		var/failures = 0
+		var/obj/item/I = new R.path
+		if(I.matter)
+			if(!R.resources)
+				failures++
+				log_bad("[R.name] - recipe does not have a resource requirement, but item contains matter.")
+			else
+				for(var/material in I.matter)
+					if(R.resources[material] != I.matter[material] * EXTRA_COST_FACTOR)
+						failures++
+						log_bad("[R.name] - recipe [material] requirement is [R.resources[material]], but should be [I.matter[material] * EXTRA_COST_FACTOR].")
+		else if(R.resources)
+			log_debug("[R.name] - recipe requires resources, but item does not contain matter.")
+
+		qdel(I)
+
+		if(failures > 0)
+			bad_tests++
+
+	if(bad_tests)
+		fail("[bad_tests] autolathe recipe\s had material costs inconsistent with item matter.")
+	else
+		pass("All autolathe recipes had material costs consistent with item matter.")
+
+	return 1
+
+/datum/unit_test/autolathe_control_test
+	name = "AUTOLATHE: control test"
+
+/datum/unit_test/autolathe_control_test/start_test()
+	var/bad_tests = 0
+
+	var/datum/autolathe/recipe/DR = new /datum/autolathe/recipe
+
+	if(ispath(DR.path))
+		bad_tests++
+		log_bad("TEST RECIPE - initializes with a path")
+	if(DR.category)
+		bad_tests++
+		log_bad("TEST RECIPE - initializes with a category.")
+	if(DR.is_stack)
+		bad_tests++
+		log_bad("TEST RECIPE - is a stack.")
+	if(DR.resources)
+		bad_tests++
+		log_bad("TEST RECIPE - has resource requirement.")
+
+	if(bad_tests)
+		fail("Autolathe test recipe failed [bad_tests] initialization tests.")
+	else
+		pass("Autolathe test recipe passed all initialization tests.")
+
+	return 1

--- a/code/unit_tests/autolathe_tests.dm
+++ b/code/unit_tests/autolathe_tests.dm
@@ -108,13 +108,13 @@
 		if(autolathe_items.Find(R.path))
 			bad_tests++
 			log_bad("[R.name] - duplicate autolathe recipe/s found with path [R.path].")
-		list.Add(R.path)
+		autolathe_items.Add(R.path)
 
 	for(var/datum/design/item/R in protolathe_recipes)
 		if(protolathe_items.Find(R.build_path))
 			bad_tests++
-			log_bad("[R.name] - duplicate protolathe recipe/s found with path [R.path].")
-		list.Add(R.path)
+			log_bad("[R.name] - duplicate protolathe recipe/s found with path [R.build_path].")
+		protolathe_items.Add(R.build_path)
 
 	for(var/R in autolathe_items)
 		if(protolathe_items.Find(R))

--- a/code/unit_tests/autolathe_tests.dm
+++ b/code/unit_tests/autolathe_tests.dm
@@ -93,3 +93,40 @@
 		pass("Autolathe test recipe passed all initialization tests.")
 
 	return 1
+
+/datum/unit_test/autolathe_dupe_test
+	name = "AUTOLATHE: duplicate recipe test"
+
+/datum/unit_test/autolathe_dupe_test/start_test()
+	var/bad_tests = 0
+	var/warn_tests = 0
+
+	var/list/autolathe_items = list()
+	var/list/protolathe_items = list()
+
+	for(var/datum/autolathe/recipe/R in autolathe_recipes)
+		if(autolathe_items.Find(R.path))
+			bad_tests++
+			log_bad("[R.name] - duplicate autolathe recipe/s found with path [R.path].")
+		list.Add(R.path)
+
+	for(var/datum/design/item/R in protolathe_recipes)
+		if(protolathe_items.Find(R.build_path))
+			bad_tests++
+			log_bad("[R.name] - duplicate protolathe recipe/s found with path [R.path].")
+		list.Add(R.path)
+
+	for(var/R in autolathe_items)
+		if(protolathe_items.Find(R))
+			warn_tests++
+			log_debug("Path [R] - recipe is shared between both autolathe and protolathe.")
+
+	autolathe_items = null
+	protolathe_items = null
+
+	if(bad_tests)
+		fail("[bad_tests] autolathe or protolathe recipe\s had duplicate paths.")
+	else
+		pass("No duplicate recipes found, and [warn_tests] shared autolathe/protolathe recipe/s found.")
+
+	return 1

--- a/persistentss13.dme
+++ b/persistentss13.dme
@@ -2486,6 +2486,7 @@
 #include "code\unit_tests\alt_appearances_test.dm"
 #include "code\unit_tests\area_tests.dm"
 #include "code\unit_tests\atmospherics_tests.dm"
+#include "code\unit_tests\autolathe_tests.dm"
 #include "code\unit_tests\equipment_tests.dm"
 #include "code\unit_tests\extension_tests.dm"
 #include "code\unit_tests\food_tests.dm"

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -240,7 +240,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python tools/GenerateGlobalVarAccess/gen_globals.py persistentss13.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< '328f94bc61e8b28444059bc0debd1b45 *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< 'c7f079cc11d86682698b4d6f80a6ddee *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH persistentss13.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon persistentss13.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
The autolathe can now take any stacked material and print with any material. There is also a couple new Travis tests that ensures all autolathe recipes are valid.

To showcase this, I've added some circuits that take various precious metals (copper, silver, gold, platinum); the kind of stuff you'd need to start up a station before you can get an R&D department running.

I eventually plan to port over most handcrafted recipes to the autolathe, and give it a category system that isn't garbage.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
