### PR TITLE
Racks shouldn't yield free plastic

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -92,7 +92,7 @@
 #define WALL_CAN_OPEN 1
 #define WALL_OPENING 2
 
-#define DEFAULT_TABLE_MATERIAL "plastic"
+#define DEFAULT_TABLE_MATERIAL "steel"
 #define DEFAULT_WALL_MATERIAL "steel"
 
 #define SHARD_SHARD "shard"

--- a/code/modules/tables/rack.dm
+++ b/code/modules/tables/rack.dm
@@ -6,7 +6,6 @@
 	can_plate = 0
 	can_reinforce = 0
 	flipped = -1
-
 	material = DEFAULT_TABLE_MATERIAL
 
 /obj/structure/table/rack/New()


### PR DESCRIPTION
Make the default table material steel, and yield that when disassembling racks.