### PR TITLE
Fixing default gas contents in tank_types.dm

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -16,7 +16,7 @@
 	desc = "A tank of oxygen."
 	icon_state = "oxygen"
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
-	starting_pressure = list("oxygen" = 6*ONE_ATMOSPHERE)
+	starting_pressure = list("oxygen" = 10*ONE_ATMOSPHERE)
 	volume = 180
 
 /obj/item/weapon/tank/oxygen/yellow
@@ -36,8 +36,9 @@
 	desc = "A tank with an N2O/O2 gas mix."
 	icon_state = "anesthetic"
 	item_state = "an_tank"
-	starting_pressure = list("oxygen" = 6*ONE_ATMOSPHERE*O2STANDARD, "sleeping_agent" = 6*ONE_ATMOSPHERE*N2STANDARD)
-	volume = 270
+	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
+	starting_pressure = list("oxygen" = 5*ONE_ATMOSPHERE*O2STANDARD, "sleeping_agent" = 5*ONE_ATMOSPHERE*N2STANDARD)
+	volume = 180
 
 /*
  * Air


### PR DESCRIPTION
Tanks (full size) now have a full 10xpressure in it by default.
Anesthetic:
* Modified volume to match default tanks instead of being super meta by having a higher potential volume
* Fixed the numbers so it won't explode when you spawn it in
* defaults to a distribute pressure so people won't suffocate automatically when you try using it on them
* You could also change the ratio of oxygen to nitrogen for more breathable gas, but it's not necessary
* May have screwed it up and result in n2o tanks being even less filled due to how game mechanics work. Fixing just requires upping to 10/10 atmos on the gasses