### PR TITLE
default gas tank gas amounts

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -36,9 +36,9 @@
 	desc = "A tank with an N2O/O2 gas mix."
 	icon_state = "anesthetic"
 	item_state = "an_tank"
-	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
+	w_class = ITEM_SIZE_LARGE
 	starting_pressure = list("oxygen" = 10*ONE_ATMOSPHERE*O2STANDARD, "sleeping_agent" = 10*ONE_ATMOSPHERE*N2STANDARD)
-	volume = 180
+	volume = 270
 
 /*
  * Air

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -36,7 +36,7 @@
 	desc = "A tank with an N2O/O2 gas mix."
 	icon_state = "anesthetic"
 	item_state = "an_tank"
-	w_class = ITEM_SIZE_LARGE
+	w_class = ITEM_SIZE_HUGE
 	starting_pressure = list("oxygen" = 10*ONE_ATMOSPHERE*O2STANDARD, "sleeping_agent" = 10*ONE_ATMOSPHERE*N2STANDARD)
 	volume = 270
 


### PR DESCRIPTION
Oxygen tanks (full size) now has a full 10xpressure in it by default.
Anesthetic:
*Now start full
*Modified volume to match default tanks instead of being super meta by having a higher potential volume
*Hopefully won't explode
*Defaults to a distribute pressure so people won't suffocate automatically when you try using it on them