### PR TITLE
Access control Imports only

### DIFF
--- a/code/modules/factions/faction.dm
+++ b/code/modules/factions/faction.dm
@@ -152,7 +152,7 @@ GLOBAL_LIST_EMPTY(all_world_factions)
 	accesses["5"] = "Security Programs"
 	accesses["6"] = "Networking Programs"
 	accesses["7"] = "Lock Electronics"
-	accesses["8"] = "Import/Export Approval"
+	accesses["8"] = "Import Approval"
 	accesses["9"] = "Science Machinery & Programs"
 	
 /obj/faction_spawner

--- a/code/modules/modular_computers/file_system/programs/generic/invoicing.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/invoicing.dm
@@ -8,7 +8,6 @@
 	size = 21
 	available_on_ntnet = 1
 	requires_ntnet = 1
-	required_access = core_access_order_approval
 
 /datum/nano_module/program/invoicing
 	name = "Invoicing program"

--- a/nano/templates/faction_core.tmpl
+++ b/nano/templates/faction_core.tmpl
@@ -52,7 +52,7 @@
 		Core Access - Core access cannot be deleted or used outside their named purpose.<br>
 		<br>
 		{{:helper.link("(1) Logistic Control, Leadership", '', {'action' : 'none'})}}{{:helper.link("(2) Command Programs", '', {'action' : 'none'})}}{{:helper.link("(3) Engineering Programs", '', {'action' : 'none'})}}
-		{{:helper.link("(4) Medical Programs", '', {'action' : 'none'})}}{{:helper.link("(5) Security Programs", '', {'action' : 'none'})}}{{:helper.link("(6) Networking Programs", '', {'action' : 'none'})}}{{:helper.link("(7) Lock Electronics", '', {'action' : 'none'})}}{{:helper.link("(8) Import/Export Approval", '', {'action' : 'none'})}}{{:helper.link("(9) Science Machinery & Programs", '', {'action' : 'none'})}}{{:helper.link("(10) Reserved", '', {'action' : 'none'})}}
+		{{:helper.link("(4) Medical Programs", '', {'action' : 'none'})}}{{:helper.link("(5) Security Programs", '', {'action' : 'none'})}}{{:helper.link("(6) Networking Programs", '', {'action' : 'none'})}}{{:helper.link("(7) Lock Electronics", '', {'action' : 'none'})}}{{:helper.link("(8) Import Approval", '', {'action' : 'none'})}}{{:helper.link("(9) Science Machinery & Programs", '', {'action' : 'none'})}}{{:helper.link("(10) Reserved", '', {'action' : 'none'})}}
 		<br><br><br><br><hr><br>
 		{{for data.access_categories}}
 			{{:helper.link(value.name, '', {'action' : 'select_accesscategory', 'selected_ref' : value.ref})}}{{:helper.link("Create new access", '', {'action' : 'create_access_two', 'selected_ref' : value.ref})}}:<br><br>

--- a/nano/templates/supply.tmpl
+++ b/nano/templates/supply.tmpl
@@ -106,27 +106,23 @@
 	{{/for}}
 		
 {{else data.screen == 6}}
-	{{if data.is_admin}}
-		<div class="item">
-			<div class="itemLabel">
-				Export Telepad Selection:
-			</div>
-			<div class="itemContent">
-				{{for data.telepads}}
-					{{:helper.link(value.name, '', {'toggle_telepad_export' : value.ref},null, value.selected ? 'selected' : null )}}
-				{{/for}}
-			</div>
+	<div class="item">
+		<div class="itemLabel">
+			Export Telepad Selection:
 		</div>
-		<hr>
-		<div class="item">
-			<div class="itemLabel">
-				Send Valid Exports:
-			</div>
-			<div class="itemContent">
-				{{:helper.link('Initiate Telepads', 'check', {'launch_export' : 1})}}
-			</div>
+		<div class="itemContent">
+			{{for data.telepads}}
+				{{:helper.link(value.name, '', {'toggle_telepad_export' : value.ref},null, value.selected ? 'selected' : null )}}
+			{{/for}}
 		</div>
-	{{else}}
-		<h3>Access denied: Missing identificaton or insufficient permissions.</h3>
-	{{/if}}
+	</div>
+	<hr>
+	<div class="item">
+		<div class="itemLabel">
+			Send Valid Exports:
+		</div>
+		<div class="itemContent">
+			{{:helper.link('Initiate Telepads', 'check', {'launch_export' : 1})}}
+		</div>
+	</div>
 {{/if}}


### PR DESCRIPTION
This change will allow stations to control import access independently. Exports and invoicing will no longer be access-controlled, since all you can do with these things is make money for the station.

- The Send Exports tab no longer requires admin authentication
- The Invoicing program no longer requires admin authentication
- The `core_access_order_approval` permission is now called "Import Approval" instead of "Import/Export Approval"