### PR TITLE
Save improvement Part 1/3, Saving Records as its own file

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -45,7 +45,7 @@
 	var/related_accounts_ip = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this ip
 	var/related_accounts_cid = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this computer id
 
-	preload_rsc = 0 // This is 0 so we can set it to an URL once the player logs in and have them download the resources from a different server.
+	preload_rsc = 2 // This is 0 so we can set it to an URL once the player logs in and have them download the resources from a different server.
 	var/static/obj/screen/click_catcher/void
 
 	var/reset_stretch = 0 //Used by things that fiddle with client's stretch-to-fit.

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -125,7 +125,7 @@
 
 	// Change the way they should download resources.
 	if(config.resource_urls && config.resource_urls.len)
-		src.preload_rsc = pick(config.resource_urls)
+		src.preload_rsc = 2//pick(config.resource_urls)
 	else src.preload_rsc = 2 // If config.resource_urls is not set, preload like normal.
 
 	if(byond_version < DM_VERSION)

--- a/code/modules/world_save/map_storage.dm
+++ b/code/modules/world_save/map_storage.dm
@@ -292,11 +292,9 @@ var/global/list/debug_data = list()
 	for(var/zone/Z in zones_to_save)
 		Z.turf_coords = Z.get_turf_coords()
 		zones |= Z
-	f["factions"] << GLOB.all_world_factions
 	f["zones"] << zones
 	f["areas"] << formatted_areas
 	f["turbolifts"] << turbolifts
-	f["records"] << GLOB.all_crew_records
 	var/savefile/q = new("map_saves/records.sav")
 	q << GLOB.all_world_factions
 	q << GLOB.all_crew_records
@@ -358,11 +356,13 @@ var/global/list/debug_data = list()
 	
 //	var/savefile/q = new("map_saves/records.sav")
 	
+//	q >> GLOB.all_world_factions
 //	if(!GLOB.all_world_factions)
 //		GLOB.all_world_factions = list()
 //	for(var/ind in 1 to all_loaded.len)
 //		var/datum/dat = all_loaded[ind]
 //		dat.after_load()
+//	q >> GLOB.all_crew_records
 //	if(!GLOB.all_crew_records)
 //		GLOB.all_crew_records = list()
 	all_loaded = list()

--- a/code/modules/world_save/map_storage.dm
+++ b/code/modules/world_save/map_storage.dm
@@ -358,13 +358,11 @@ var/global/list/debug_data = list()
 	
 //	var/savefile/q = new("map_saves/records.sav")
 	
-//	q >> GLOB.all_world_factions
 //	if(!GLOB.all_world_factions)
 //		GLOB.all_world_factions = list()
 //	for(var/ind in 1 to all_loaded.len)
 //		var/datum/dat = all_loaded[ind]
 //		dat.after_load()
-//	q >> GLOB.all_crew_records
 //	if(!GLOB.all_crew_records)
 //		GLOB.all_crew_records = list()
 	all_loaded = list()

--- a/code/modules/world_save/map_storage.dm
+++ b/code/modules/world_save/map_storage.dm
@@ -268,7 +268,9 @@ var/global/list/debug_data = list()
 		else
 			backup = 1
 			fcopy("map_saves/game.sav", "backups/[dir].sav")
+			fcopy("map_saves/records.sav", "backups/[dir]-r.sav")
 	fdel("map_saves/game.sav")
+	fdel("map_saves/records.sav")
 	var/savefile/f = new("map_saves/game.sav")
 	found_vars = list()
 	for(var/z in 1 to 27)
@@ -295,6 +297,9 @@ var/global/list/debug_data = list()
 	f["areas"] << formatted_areas
 	f["turbolifts"] << turbolifts
 	f["records"] << GLOB.all_crew_records
+	var/savefile/q = new("map_saves/records.sav")
+	q << GLOB.all_world_factions
+	q << GLOB.all_crew_records
 	world << "Saving Completed in [(REALTIMEOFDAY - starttime)/10] seconds!"
 	world << "Saving Complete"
 	return 1
@@ -350,9 +355,18 @@ var/global/list/debug_data = list()
 			Z.contents |= T
 	for(var/zone/Z in zones)
 		Z.rebuild()
+	
+	var/savefile/q = new("map_saves/records.sav")
+	
+	q >> GLOB.all_world_factions
+	if(!GLOB.all_world_factions)
+		GLOB.all_world_factions = list()
 	for(var/ind in 1 to all_loaded.len)
 		var/datum/dat = all_loaded[ind]
 		dat.after_load()
+	q >> GLOB.all_crew_records
+	if(!GLOB.all_crew_records)
+		GLOB.all_crew_records = list()
 	all_loaded = list()
 	SSmachines.makepowernets()
 	for(var/x in debug_data)

--- a/code/modules/world_save/map_storage.dm
+++ b/code/modules/world_save/map_storage.dm
@@ -356,17 +356,17 @@ var/global/list/debug_data = list()
 	for(var/zone/Z in zones)
 		Z.rebuild()
 	
-	var/savefile/q = new("map_saves/records.sav")
+//	var/savefile/q = new("map_saves/records.sav")
 	
-	q >> GLOB.all_world_factions
-	if(!GLOB.all_world_factions)
-		GLOB.all_world_factions = list()
-	for(var/ind in 1 to all_loaded.len)
-		var/datum/dat = all_loaded[ind]
-		dat.after_load()
-	q >> GLOB.all_crew_records
-	if(!GLOB.all_crew_records)
-		GLOB.all_crew_records = list()
+//	q >> GLOB.all_world_factions
+//	if(!GLOB.all_world_factions)
+//		GLOB.all_world_factions = list()
+//	for(var/ind in 1 to all_loaded.len)
+//		var/datum/dat = all_loaded[ind]
+//		dat.after_load()
+//	q >> GLOB.all_crew_records
+//	if(!GLOB.all_crew_records)
+//		GLOB.all_crew_records = list()
 	all_loaded = list()
 	SSmachines.makepowernets()
 	for(var/x in debug_data)


### PR DESCRIPTION
In an effort to reduce RAM use, I'm going to be trying a number of things to split the files. This makes records and factions stored in a records.sav file, I've already tested the full system, but I need to merge it in three parts because I need to first

Have the server load like it used to, but save with the new files generated, then

Merge the other half and restart, so that the load now uses the new files and not the old save, and finally

Make the final change which takes the old unnecessary save protocols out, this is saved for last so that any files created prior to this are valid backups.
