### PR TITLE
Nice autolathe + sane recycler

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -184,10 +184,8 @@
 			var/obj/item/stack/stack = eating
 			total_material *= stack.get_amount()
 		else
-			world << "A total_material: [total_material]"
 			total_material *= 0.7 + (1 - mat_efficiency)	//everything else gets a multiplier of 0.7 + 0.1 for each manipulator level above 1, totals a maximum of 0.9
 			total_material = round(total_material)
-			world << "B total_material: [total_material]"
 
 		if(stored_material[material] + total_material > storage_capacity)
 			total_material = storage_capacity - stored_material[material]

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -9,10 +9,11 @@
 	active_power_usage = 2000
 	clicksound = "keyboard"
 	clickvol = 30
+	multiplier = 1
 
 	var/list/machine_recipes
-	var/list/stored_material =  list(DEFAULT_WALL_MATERIAL = 0, "glass" = 0)
-	var/list/storage_capacity = list(DEFAULT_WALL_MATERIAL = 0, "glass" = 0)
+	var/list/stored_material = list(DEFAULT_WALL_MATERIAL = 0, "glass" = 0)
+	var/list/storage_capacity = 0
 	var/show_category = "All"
 
 	var/hacked = 0
@@ -25,9 +26,7 @@
 
 	var/datum/wires/autolathe/wires = null
 
-
 /obj/machinery/autolathe/New()
-
 	..()
 	wires = new(src)
 	//Create parts for lathe.
@@ -69,9 +68,10 @@
 
 		for(var/material in stored_material)
 			material_top += "<td width = '25%' align = center><b>[material]</b></td>"
-			material_bottom += "<td width = '25%' align = center>[stored_material[material]]<b>/[storage_capacity[material]]</b></td>"
+			material_bottom += "<td width = '25%' align = center>[stored_material[material]]<b>/[storage_capacity]</b></td>"
 
 		dat += "[material_top]</tr>[material_bottom]</tr></table><hr>"
+		dat += GetMultiplierForm(src)
 		dat += "<h2>Printable Designs</h2><h3>Showing: <a href='?src=\ref[src];change_category=1'>[show_category]</a>.</h3></center><table width = '100%'>"
 
 		var/index = 0
@@ -87,18 +87,24 @@
 			if(!R.resources || !R.resources.len)
 				material_string = "No resources required.</td>"
 			else
+				//Fucking stacks should never get a bonus due to having "REALLY good manipulators"
+				var/actual_efficiency = 1
+				if(!istype(R.path, /obj/item/stack))
+					actual_efficiency = mat_efficiency
 				//Make sure it's buildable and list requires resources.
 				for(var/material in R.resources)
-					var/sheets = round(stored_material[material]/round(R.resources[material]*mat_efficiency))
+					if(!stored_material[material])
+						stored_material[material] = 0
+					var/sheets = round(stored_material[material]/round(R.resources[material]*actual_efficiency*multiplier))
 					if(isnull(max_sheets) || max_sheets > sheets)
 						max_sheets = sheets
-					if(!isnull(stored_material[material]) && stored_material[material] < round(R.resources[material]*mat_efficiency))
+					if(stored_material[material] < round(R.resources[material]*actual_efficiency*multiplier))
 						can_make = 0
 					if(!comma)
 						comma = 1
 					else
 						material_string += ", "
-					material_string += "[round(R.resources[material] * mat_efficiency)] [material]"
+					material_string += "[round(R.resources[material] * actual_efficiency * multiplier)] [material]"
 				material_string += ".<br></td>"
 				//Build list of multipliers for sheets.
 				if(R.is_stack)
@@ -111,7 +117,7 @@
 							multiplier_string  += "<a href='?src=\ref[src];make=[index];multiplier=[i]'>\[x[i]\]</a>"
 						multiplier_string += "<a href='?src=\ref[src];make=[index];multiplier=[max_sheets]'>\[x[max_sheets]\]</a>"
 
-			dat += "<tr><td width = 180>[R.hidden ? "<font color = 'red'>*</font>" : ""]<b>[can_make ? "<a href='?src=\ref[src];make=[index];multiplier=1'>" : ""][R.name][can_make ? "</a>" : ""]</b>[R.hidden ? "<font color = 'red'>*</font>" : ""][multiplier_string]</td><td align = right>[material_string]</tr>"
+			dat += "<tr><td width = 180>[R.hidden ? "<font color = 'red'>*</font>" : ""]<b>[can_make ? "<a href='?src=\ref[src];make=[index];multiplier=1'>" : ""][R.name][multiplier > 1 ? " x[multiplier]" : ""][can_make ? "</a>" : ""]</b>[R.hidden ? "<font color = 'red'>*</font>" : ""][multiplier_string]</td><td align = right>[material_string]</tr>"
 
 		dat += "</table><hr>"
 	//Hacking.
@@ -121,7 +127,9 @@
 
 		dat += "<hr>"
 
-	user << browse(dat, "window=autolathe")
+	var/datum/browser/popup = new(usr, "autolathe", "Autolathe Control Panel")
+	popup.set_content(jointext(dat, null))
+	popup.open()
 	onclose(user, "autolathe")
 
 /obj/machinery/autolathe/attackby(var/obj/item/O as obj, var/mob/user as mob)
@@ -164,11 +172,9 @@
 	var/mass_per_sheet = 0 // Amount of material constituting one sheet.
 
 	for(var/material in eating.matter)
-
-		if(isnull(stored_material[material]) || isnull(storage_capacity[material]))
-			continue
-
-		if(stored_material[material] >= storage_capacity[material])
+		if(!stored_material[material])
+			stored_material[material] = 0
+		if(stored_material[material] >= storage_capacity)
 			continue
 
 		var/total_material = eating.matter[material]
@@ -177,17 +183,20 @@
 		if(istype(eating,/obj/item/stack))
 			var/obj/item/stack/stack = eating
 			total_material *= stack.get_amount()
+		else
+			world << "A total_material: [total_material]"
+			total_material *= 0.7 + (1 - mat_efficiency)	//everything else gets a multiplier of 0.7 + 0.1 for each manipulator level above 1, totals a maximum of 0.9
+			total_material = round(total_material)
+			world << "B total_material: [total_material]"
 
-		if(stored_material[material] + total_material > storage_capacity[material])
-			total_material = storage_capacity[material] - stored_material[material]
+		if(stored_material[material] + total_material > storage_capacity)
+			total_material = storage_capacity - stored_material[material]
 			filltype = 1
 		else
 			filltype = 2
-
 		stored_material[material] += total_material
 		total_used += total_material
 		mass_per_sheet += eating.matter[material]
-
 	if(!filltype)
 		to_chat(user, "<span class='notice'>\The [src] is full. Please remove material from the autolathe in order to insert more.</span>")
 		return
@@ -224,6 +233,10 @@
 		to_chat(usr, "<span class='notice'>The autolathe is busy. Please wait for completion of previous operation.</span>")
 		return
 
+	if(ProcessMultiplierForm(src, href_list))
+		src.updateUsrDialog()
+		return
+
 	if(href_list["change_category"])
 
 		var/choice = input("Which category do you wish to display?") as null|anything in autolathe_categories+"All"
@@ -233,50 +246,62 @@
 	if(href_list["make"] && machine_recipes)
 
 		var/index = text2num(href_list["make"])
-		var/multiplier = text2num(href_list["multiplier"])
+		var/stack_multiplier = text2num(href_list["multiplier"])
 		var/datum/autolathe/recipe/making
 
 		if(index > 0 && index <= machine_recipes.len)
 			making = machine_recipes[index]
 
 		//Exploit detection, not sure if necessary after rewrite.
-		if(!making || multiplier < 0 || multiplier > 100)
-			var/turf/exploit_loc = get_turf(usr)
-			message_admins("[key_name_admin(usr)] tried to exploit an autolathe to duplicate an item! ([exploit_loc ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[exploit_loc.x];Y=[exploit_loc.y];Z=[exploit_loc.z]'>JMP</a>" : "null"])", 0)
-			log_admin("EXPLOIT : [key_name(usr)] tried to exploit an autolathe to duplicate an item!")
-			return
+		//Not necessary, loop breaks if you can't afford shit
+		//if(!making || stack_multiplier < 0 || stack_multiplier > 100)
+		//	var/turf/exploit_loc = get_turf(usr)
+		//	message_admins("[key_name_admin(usr)] tried to exploit an autolathe to duplicate an item! ([exploit_loc ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[exploit_loc.x];Y=[exploit_loc.y];Z=[exploit_loc.z]'>JMP</a>" : "null"])", 0)
+		//	log_admin("EXPLOIT : [key_name(usr)] tried to exploit an autolathe to duplicate an item!")
+		//	return
 
+		var/mult = multiplier
+		//Fucking stacks should never get a bonus due to having "REALLY good manipulators"
+		var/actual_efficiency = 1
+		if(!istype(making.path, /obj/item/stack))
+			actual_efficiency = mat_efficiency
 		busy = 1
 		update_use_power(2)
+		var/longest_spawn = 0
+		for(var/i = 0, i < mult, i++)
+			//Check if we still have the materials.
+			var/break_mult = 0
+			for(var/material in making.resources)
+				if(!isnull(stored_material[material]))
+					if(stored_material[material] < round(making.resources[material] * actual_efficiency) * stack_multiplier)
+						break_mult = 1
+						break
+			if(break_mult)
+				break
+			longest_spawn = build_time + (build_time * i)
+			//Consume materials.
+			for(var/material in making.resources)
+				if(!isnull(stored_material[material]))
+					stored_material[material] = max(0, stored_material[material] - round(making.resources[material] * actual_efficiency) * stack_multiplier)
 
-		//Check if we still have the materials.
-		for(var/material in making.resources)
-			if(!isnull(stored_material[material]))
-				if(stored_material[material] < round(making.resources[material] * mat_efficiency) * multiplier)
-					return
-
-		//Consume materials.
-		for(var/material in making.resources)
-			if(!isnull(stored_material[material]))
-				stored_material[material] = max(0, stored_material[material] - round(making.resources[material] * mat_efficiency) * multiplier)
-
-		//Fancy autolathe animation.
-		flick("autolathe_n", src)
-
-		sleep(build_time)
-
-		busy = 0
-		update_use_power(1)
-
-		//Sanity check.
-		if(!making || !src) return
-
-		//Create the desired item.
-		var/obj/item/I = new making.path(loc)
-		if(multiplier > 1 && istype(I, /obj/item/stack))
-			var/obj/item/stack/S = I
-			S.amount = multiplier
-			S.update_icon()
+			spawn(longest_spawn)
+				//Sanity check.
+				if(!src) return
+				//Create the desired item.
+				var/obj/item/I = new making.path(loc)
+				if(stack_multiplier > 1 && istype(I, /obj/item/stack))
+					var/obj/item/stack/S = I
+					S.amount = stack_multiplier
+					S.update_icon()
+				//Time to prevent free materials at higher levels, 0.8 cost multiplier + 0.9 gain multiplier hmmmm yumyum spicey
+				if(!istype(I, /obj/item/stack))
+					for(var/material in I.matter)
+						I.matter[material] = round(I.matter[material] * actual_efficiency)
+				//Fancy autolathe animation.
+				flick("autolathe_n", src)
+		spawn(longest_spawn)
+			busy = 0
+			update_use_power(1)
 
 	updateUsrDialog()
 
@@ -293,13 +318,13 @@
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
 		man_rating += M.rating
 
-	storage_capacity[DEFAULT_WALL_MATERIAL] = mb_rating  * 25000
-	storage_capacity["glass"] = mb_rating  * 12500
-	build_time = 50 / man_rating
-	mat_efficiency = 1.1 - man_rating * 0.1// Normally, price is 1.25 the amount of material, so this shouldn't go higher than 0.8. Maximum rating of parts is 3
+	var/material/M = get_material_by_name(DEFAULT_WALL_MATERIAL)
+	var/obj/item/stack/material/S = M.stack_type
+	storage_capacity = mb_rating * initial(S.perunit) * 15
+	build_time = 30 / man_rating
+	mat_efficiency = 1.1 - man_rating * 0.1	//You get a slight discount on items with better parts, also affects the recycling penalty of the autolathe (AKA use the recycler)
 
 /obj/machinery/autolathe/dismantle()
-
 	for(var/mat in stored_material)
 		var/material/M = get_material_by_name(mat)
 		if(!istype(M))

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -1,8 +1,10 @@
 /var/global/list/autolathe_recipes
 /var/global/list/autolathe_categories
 
-var/const/EXTRA_COST_FACTOR = 1.25
+var/const/EXTRA_COST_FACTOR = 1
 // Items are more expensive to produce than they are to recycle.
+// Yeah but just make recycling bad
+// Extra cost factor implies you are DELETING steel (1st law of thermodynamics)
 
 /proc/populate_lathe_recipes()
 
@@ -372,7 +374,7 @@ var/const/EXTRA_COST_FACTOR = 1.25
 
 /datum/autolathe/recipe/cable_coil
 	name = "cable coil"
-	path = /obj/item/stack/cable_coil/single
+	path = /obj/item/stack/cable_coil
 	category = "Devices and Components"
 	is_stack = 1
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -115,6 +115,7 @@ Class Procs:
 	var/interact_offline = 0 // Can the machine be interacted with while de-powered.
 	var/clicksound			// sound played on succesful interface use by a carbon lifeform
 	var/clickvol = 40		// sound played on succesful interface use
+	var/multiplier = 0
 
 /obj/machinery/Initialize(mapload, d=0)
 	. = ..()
@@ -353,3 +354,32 @@ Class Procs:
 	..()
 	if(clicksound && istype(user, /mob/living/carbon))
 		playsound(src, clicksound, clickvol)
+
+//Defined at machinery level so that it can be used everywhere with little effort.
+/obj/machinery/proc/HasMultiplier()
+	return initial(multiplier) > 0
+
+/obj/machinery/proc/GetMultiplierForm(var/obj/machinery/M)
+	var/dat = ""
+	if(!M.HasMultiplier())
+		return dat
+	dat += {"<form name='update_mult' action='?src=\ref[M]'>
+				<input type='hidden' name='src' value='\ref[M]'>
+				<input type='hidden' name='update_mult' value='input'>
+				Multiplier:
+				<input type='text' name='input' value='[M:multiplier]' size='3'>
+				<input type='submit' class='button' value='Enter'>
+				<A href='?src=\ref[M];update_mult=1;input=1'>X</A>
+			</form>"}
+	dat += "<hr>"
+	return dat
+
+/obj/machinery/proc/ProcessMultiplierForm(var/obj/machinery/M, var/list/href_list)
+	if(!M.HasMultiplier())
+		return 0
+	var/new_mult = text2num(href_list["input"])
+	if(isnum(new_mult))
+		new_mult = min(25, max(1, round(new_mult, 1))) //multiplier has to be at least 1, maximum of 20
+		M.multiplier = new_mult
+		return 1
+	return 0

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -103,13 +103,13 @@ var/const/SAFETY_COOLDOWN = 100
 
 /obj/machinery/recycler/proc/recycle(var/obj/item/I, var/sound = 1)
 	I.loc = src.loc
-	if(!istype(I, /obj/item/weapon/disk/nuclear))
+	if(!istype(I, /obj/item/weapon/disk/nuclear) && !istype(I, /obj/item/stack))
 		for(var/mat in I.matter)
 			stored_material[mat] += I.matter[mat]
 			var/material/M = get_material_by_name(mat)
 			if(!istype(M))
 				continue
-			var/obj/item/stack/material/S = new M.stack_type(get_turf(src))
+			var/obj/item/stack/material/S = new M.stack_type(loc)
 			if(stored_material[mat] > S.perunit)
 				S.amount = round(stored_material[mat] / S.perunit)
 				stored_material[mat] -= S.amount * S.perunit

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -14,6 +14,7 @@ var/const/SAFETY_COOLDOWN = 100
 	var/blood = 0
 	var/eat_dir = WEST
 	var/amount_produced = 1
+	var/list/stored_material = list()
 
 /obj/machinery/recycler/New()
 	// On us
@@ -76,7 +77,6 @@ var/const/SAFETY_COOLDOWN = 100
 
 
 /obj/machinery/recycler/Bumped(var/atom/movable/AM)
-
 	if(stat & (BROKEN|NOPOWER))
 		return
 	if(safety_mode)
@@ -88,7 +88,6 @@ var/const/SAFETY_COOLDOWN = 100
 			grinding = 0
 	else
 		return
-
 	var/move_dir = get_dir(loc, AM.loc)
 	if(move_dir == eat_dir)
 		if(isliving(AM))
@@ -105,15 +104,18 @@ var/const/SAFETY_COOLDOWN = 100
 /obj/machinery/recycler/proc/recycle(var/obj/item/I, var/sound = 1)
 	I.loc = src.loc
 	if(!istype(I, /obj/item/weapon/disk/nuclear))
-		del(I)
-		if(prob(15))
-			new /obj/item/stack/material/steel(loc)
-		if(prob(10))
-			new /obj/item/stack/material/glass(loc)
-		if(prob(2))
-			new /obj/item/stack/material/plasteel(loc)
-		if(prob(1))
-			new /obj/item/stack/material/glass(loc)
+		for(var/mat in I.matter)
+			stored_material[mat] += I.matter[mat]
+			var/material/M = get_material_by_name(mat)
+			if(!istype(M))
+				continue
+			var/obj/item/stack/material/S = new M.stack_type(get_turf(src))
+			if(stored_material[mat] > S.perunit)
+				S.amount = round(stored_material[mat] / S.perunit)
+				stored_material[mat] -= S.amount * S.perunit
+			else
+				qdel(S)
+		qdel(I)
 		if(sound)
 			playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -5,7 +5,7 @@
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 
 	var/image/blood_overlay = null //this saves our blood splatter overlay, which will be processed not to go over the edges of the sprite
-	var/randpixel = 6
+	var/randpixel = 9
 	var/r_speed = 1.0
 	var/health = null
 	var/burn_point = null

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -31,7 +31,7 @@ exactly 13 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 8 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 46 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
-exactly 840 "<< uses" '(?<!<)<<(?!<)' -P
+exactly 839 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 38 "text2path uses" 'text2path'
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong


### PR DESCRIPTION
Added multiplier to machinery. 
Implemented multiplier for autolathe. 
Fixed wire coil recipe.
Fixed poor math on autolathe recipe. 
Fixed autolathe using an ancient window method. 
Allowed autolathe to take any material. 
Buffed autolathe storage and crafting speed.

Recycler now eats materials of items and spits out sheets of the correct stuff. 
Recycler doesn't recycle any type of stack.

Increased default item spread.