### PR TITLE
Fixes a Couple Bugs

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -88,6 +88,8 @@
 	storage_ui.show_to(user)
 
 /obj/item/weapon/storage/proc/prepare_ui()
+	if(ispath(storage_ui))
+		storage_ui = new storage_ui(src)
 	if(!storage_ui || !istype(storage_ui))
 		storage_ui = new()
 	storage_ui.prepare_ui()
@@ -323,10 +325,7 @@
 	for(var/obj/item/I in contents)
 		remove_from_storage(I, T, 1)
 	update_ui_after_item_removal()
-/obj/item/weapon/storage/after_load()
-	storage_ui = new storage_ui(src)
-	prepare_ui()
-	..()
+
 /obj/item/weapon/storage/Initialize()
 	. = ..()
 	if(allow_quick_empty)
@@ -342,7 +341,6 @@
 	if(isnull(max_storage_space) && !isnull(storage_slots))
 		max_storage_space = storage_slots*base_storage_cost(max_w_class)
 
-	storage_ui = new storage_ui(src)
 	prepare_ui()
 	spawn(100)
 		if(!map_storage_loaded)
@@ -359,6 +357,10 @@
 						for(var/i in 1 to (isnull(data)? 1 : data))
 							new item_path(src)
 				update_icon()
+
+/obj/item/weapon/storage/after_load()
+	. = ..()
+	prepare_ui()
 
 /obj/item/weapon/storage/emp_act(severity)
 	if(!istype(src.loc, /mob/living))

--- a/code/modules/client/preference_setup/global/02_settings.dm
+++ b/code/modules/client/preference_setup/global/02_settings.dm
@@ -101,7 +101,7 @@
 	if(prefs)
 		var/datum/client_preference/cp = get_client_preference(preference)
 		if(cp)
-			return prefs.preference_values[cp.key]
+			return prefs.preference_values[cp.key] ? prefs.preference_values[cp.key] : null
 		else
 			return null
 	else


### PR DESCRIPTION
Fixes a storage bug that would cause every storage item to freak out whenever it was loaded in. Also fixes a minor bug with preference detection.
<!-- 
!!IMPORTANT!!
Changes must be reviewed and approved by a developer before being merged.

If a developer has approved your PR, any other developer may immediately merge it, or the same developer may merge it after 24 hours.

A developer may not merge their own PR without the approval of two other developers.

Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
