### PR TITLE
Ports Bugfixes and Debug Tools From Bay

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1081,6 +1081,10 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 
 	virtual_mob = null
 
+/mob/dview/Destroy()
+	crash_with("Prevented attempt to delete dview mob: [log_info_line(src)]")
+	return QDEL_HINT_LETMELIVE // Prevents destruction
+
 /atom/proc/get_light_and_color(var/atom/origin)
 	if(origin)
 		color = origin.color

--- a/code/controllers/subsystems/processing/processing.dm
+++ b/code/controllers/subsystems/processing/processing.dm
@@ -10,6 +10,9 @@ SUBSYSTEM_DEF(processing)
 	var/list/current_run = list()
 	var/process_proc = /datum/proc/Process
 
+	var/debug_last_thing
+	var/debug_original_process_proc // initial() does not work with procs
+
 /datum/controller/subsystem/processing/stat_entry()
 	..(processing.len)
 
@@ -24,9 +27,38 @@ SUBSYSTEM_DEF(processing)
 	while(current_run.len)
 		var/datum/thing = current_run[current_run.len]
 		current_run.len--
-		if(QDELETED(thing) || (call(thing, process_proc)(wait, times_fired) == PROCESS_KILL))
+		if(QDELETED(thing) || (call(thing, process_proc)(wait, times_fired, src) == PROCESS_KILL))
 			if(thing)
 				thing.is_processing = null
 			processing -= thing
 		if (MC_TICK_CHECK)
 			return
+
+/datum/controller/subsystem/processing/proc/toggle_debug()
+	if(!check_rights(R_DEBUG))
+		return
+
+	if(debug_original_process_proc)
+		process_proc = debug_original_process_proc
+		debug_original_process_proc = null
+	else
+		debug_original_process_proc	= process_proc
+		process_proc = /datum/proc/DebugSubsystemProcess
+
+	to_chat(usr, "[name] - Debug mode [debug_original_process_proc ? "en" : "dis"]abled")
+
+/datum/controller/subsystem/processing/VV_static()
+	return ..() + list("processing", "current_run", "process_proc", "debug_last_thing", "debug_original_process_proc")
+
+/datum/proc/DebugSubsystemProcess(var/wait, var/times_fired, var/datum/controller/subsystem/processing/subsystem)
+	subsystem.debug_last_thing = src
+	var/start_tick = world.time
+	var/start_tick_usage = world.tick_usage
+	. = call(src, subsystem.debug_original_process_proc)(wait, times_fired)
+
+	var/tick_time = world.time - start_tick
+	var/tick_use_limit = world.tick_usage - start_tick_usage - 100 // Current tick use - starting tick use - 100% (a full tick excess)
+	if(tick_time > 0)
+		CRASH("[log_info_line(subsystem.debug_last_thing)] slept during processing. Spent [tick_time] tick\s.")
+	if(tick_use_limit > 0)
+		CRASH("[log_info_line(subsystem.debug_last_thing)] took longer than a tick to process. Exceeded with [tick_use_limit]%")

--- a/code/datums/weakref.dm
+++ b/code/datums/weakref.dm
@@ -11,6 +11,8 @@
 		return
 	if(QDELETED(D))
 		return
+	if(istype(D, /weakref))
+		return D
 	if(!D.weakref)
 		D.weakref = new/weakref(D)
 	return D.weakref

--- a/code/game/images.dm
+++ b/code/game/images.dm
@@ -1,3 +1,3 @@
 /image/Destroy()
 	..()
-	return QDEL_HINT_HARDDEL_NOW
+	return QDEL_HINT_HARDDEL

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -84,7 +84,7 @@
 		pixel_y = rand(3,-3)
 		START_PROCESSING(SSobj, src)
 
-/obj/effect/spider/eggcluster/New(var/location, var/atom/parent)
+/obj/effect/spider/eggcluster/New(var/mapload, var/atom/parent)
 	get_light_and_color(parent)
 	..()
 

--- a/code/modules/admin/admin_secrets.dm
+++ b/code/modules/admin/admin_secrets.dm
@@ -63,8 +63,8 @@ var/datum/admin_secrets/admin_secrets = new()
 
 /datum/admin_secret_item/proc/can_execute(var/mob/user)
 	if(can_view(user))
-		if(!warn_before_use || alert("Execute the command '[name]'?", name, "No","Yes") == "Yes")
-			return 1
+		if(!warn_before_use || alert("Execute the command '[name]'?[istext(warn_before_use) ? " [warn_before_use]" : ""]", name, "No","Yes") == "Yes")
+			return can_view(user)
 	return 0
 
 /datum/admin_secret_item/proc/execute(var/mob/user)
@@ -76,7 +76,11 @@ var/datum/admin_secrets/admin_secrets = new()
 	if(feedback)
 		feedback_inc("admin_secrets_used",1)
 		feedback_add_details("admin_secrets_used","[name]")
-	return 1
+	. = 1
+	do_execute(user)
+
+/datum/admin_secret_item/proc/do_execute(var/mob/user)
+	return
 
 /datum/admin_secret_item/Topic()
 	. = ..()
@@ -87,6 +91,9 @@ var/datum/admin_secrets/admin_secrets = new()
 *************************/
 /datum/admin_secret_category/admin_secrets
 	name = "Admin Secrets"
+
+/datum/admin_secret_category/debug
+	name = "Debug Tools"
 
 /datum/admin_secret_category/investigation
 	name = "Investigation"
@@ -108,6 +115,11 @@ var/datum/admin_secrets/admin_secrets = new()
 	category = /datum/admin_secret_category/admin_secrets
 	log = 0
 	permissions = R_ADMIN
+
+/datum/admin_secret_item/debug
+	category = /datum/admin_secret_category/debug
+	log = 1
+	permissions = R_DEBUG
 
 /datum/admin_secret_item/investigation
 	category = /datum/admin_secret_category/investigation

--- a/code/modules/admin/secrets/debug/world_types.dm
+++ b/code/modules/admin/secrets/debug/world_types.dm
@@ -1,0 +1,19 @@
+/datum/admin_secret_item/debug/instance_type_count
+	name = "Instance Type Count"
+	warn_before_use = "This is a potentially long-running operation."
+
+/datum/admin_secret_item/debug/instance_type_count/do_execute(var/mob/user)
+	var/instance_count_by_type = list()
+
+	for(var/datum/thing in world) // Atoms (don't believe its lies)
+		instance_count_by_type[thing.type]++
+
+	for (var/datum/thing) // Datums
+		instance_count_by_type[thing.type]++
+
+	for (var/client/thing) // Clients
+		instance_count_by_type[thing.type]++
+
+	for(var/instance_type in instance_count_by_type)
+		var/instance_count = instance_count_by_type[instance_type]
+		to_chat(user, "[instance_type] - [instance_count]")

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -187,7 +187,7 @@
 		if(-INFINITY to 33)
 			icon_state = "blob_factory"
 
-/obj/effect/blob/core/Initialize(loc)
+/obj/effect/blob/core/Initialize()
 	. = ..()
 	START_PROCESSING(SSobj, src)
 

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -25,12 +25,6 @@
 
 #undef NONSENSICAL_VALUE
 
-/atom/movable/New()
-	. = ..()
-	var/turf/simulated/T = loc
-	if(istype(T))
-		T.opaque_counter += opacity
-
 /atom/proc/update_light()
 	set waitfor = FALSE
 
@@ -54,7 +48,7 @@
 		light.destroy()
 		light = null
 	return ..()
-	
+
 /atom/set_opacity()
 	. = ..()
 	if(.)
@@ -62,13 +56,22 @@
 		if(istype(T))
 			T.handle_opacity_change(src)
 
-/atom/movable/Move()
-	var/turf/old_loc = loc
-	. = ..()
+#define LIGHT_MOVE_UPDATE \
+var/turf/old_loc = loc;\
+. = ..();\
+if(loc != old_loc) {\
+	for(var/datum/light_source/L in light_sources) {\
+		L.source_atom.update_light();\
+	}\
+}
 
-	if(loc != old_loc)
-		for(var/datum/light_source/L in light_sources)
-			L.source_atom.update_light()
+/atom/movable/Move()
+	LIGHT_MOVE_UPDATE
+
+/atom/movable/forceMove()
+	LIGHT_MOVE_UPDATE
+
+#undef LIGHT_MOVE_UPDATE
 
 /obj/item/equipped()
 	. = ..()

--- a/code/modules/mob/living/carbon/human/npcs.dm
+++ b/code/modules/mob/living/carbon/human/npcs.dm
@@ -31,7 +31,7 @@
 /mob/living/carbon/human/blank/New(var/new_loc)
 	..(new_loc, "Vat-Grown Human")
 
-/mob/living/carbon/human/blank/Initialize(var/new_loc)
+/mob/living/carbon/human/blank/Initialize()
 	. = ..()
 	var/number = "[pick(possible_changeling_IDs)]-[rand(1,30)]"
 	fully_replace_character_name("Subject [number]")

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -258,9 +258,7 @@ proc/get_radio_key_from_channel(var/channel)
 
 	var/speech_bubble_test = say_test(message)
 	var/image/speech_bubble = image('icons/mob/talk.dmi',src,"h[speech_bubble_test]")
-	spawn(30) qdel(speech_bubble)
 
-	// VOREStation Port - Attempt Multi-Z Talking
 	var/mob/above = src.shadow
 	while(!QDELETED(above))
 		var/turf/ST = get_turf(above)
@@ -271,12 +269,14 @@ proc/get_radio_key_from_channel(var/channel)
 			spawn(30) qdel(z_speech_bubble)
 		above = above.shadow
 
-	// VOREStation Port End
-
+	var/list/speech_bubble_recipients = list()
 	for(var/mob/M in listening)
 		if(M)
-			show_image(M, speech_bubble)
 			M.hear_say(message, verb, speaking, alt_name, italics, src, speech_sound, sound_vol)
+			if(M.client)
+				speech_bubble_recipients += M.client
+
+	flick_overlay(speech_bubble, speech_bubble_recipients, 30)
 
 	for(var/obj/O in listening_obj)
 		spawn(0)
@@ -300,7 +300,7 @@ proc/get_radio_key_from_channel(var/channel)
 				if(O) //It's possible that it could be deleted in the meantime.
 					O.hear_talk(src, stars(message), verb, speaking)
 
-	
+
 	if(whispering)
 		log_whisper("[name]/[key] : [message]")
 	else

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -18,7 +18,7 @@
 		spellremove(src)
 	ghostize()
 	..()
-	return QDEL_HINT_HARDDEL_NOW
+	return QDEL_HINT_HARDDEL
 
 /mob/proc/remove_screen_obj_references()
 	hands = null

--- a/persistentss13.dme
+++ b/persistentss13.dme
@@ -1084,6 +1084,7 @@
 #include "code\modules\admin\secrets\admin_secrets\show_law_changes.dm"
 #include "code\modules\admin\secrets\admin_secrets\show_signalers.dm"
 #include "code\modules\admin\secrets\admin_secrets\traitors_and_objectives.dm"
+#include "code\modules\admin\secrets\debug\world_types.dm"
 #include "code\modules\admin\secrets\final_solutions\summon_narsie.dm"
 #include "code\modules\admin\secrets\final_solutions\supermatter_cascade.dm"
 #include "code\modules\admin\secrets\fun_secrets\break_all_lights.dm"


### PR DESCRIPTION
To enable debugging:

- Click subsystem in the MC tab, this opens the VV window
- In the drop-down menu in the upper right select "Call Proc"
- Enter "toggle_debug", press OK, finish argument input
- Excess running times should now result in runtimes.

Shamelessly stolen from https://github.com/Baystation12/Baystation12/pull/19962

Ported this debug tool as well, which gets type counts: https://github.com/Baystation12/Baystation12/pull/21856

Also ports these bugfixes and tweaks from bay:
https://github.com/Baystation12/Baystation12/pull/19998
https://github.com/Baystation12/Baystation12/pull/20046
https://github.com/Baystation12/Baystation12/pull/20128
https://github.com/Baystation12/Baystation12/pull/20123
https://github.com/Baystation12/Baystation12/pull/20427
https://github.com/Baystation12/Baystation12/pull/20522