### PR TITLE
Factionalized wanted status and records program functionality

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -509,10 +509,10 @@ var/list/turret_icons
 	if(check_access)
 		for(var/access in H.GetAccess(connected_faction.uid))
 			if(req_access["[access]"] > 0)
-				return H.assess_perp(src, 0, 0, 1, 1)
+				return H.assess_perp(src, 0, 0, 1, 1, connected_faction)
 		return 10 //if they don't have any of the required access
 
-	return H.assess_perp(src, 0, 0, 1, 1)
+	return H.assess_perp(src, 0, 0, 1, 1, connected_faction) //if we're not checking faction or access, we're solely looking at wanted status, Arrest = pew pew
 
 /obj/machinery/porta_turret/proc/assess_bot(var/mob/living/bot/B)
 	if(!B || !istype(B))

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -244,7 +244,7 @@
 	if(emagged && !M.incapacitated()) //check incapacitated so emagged secbots don't keep attacking the same target forever
 		return 10
 
-	return M.assess_perp(access_scanner, 0, idcheck, check_records, check_arrest)
+	return M.assess_perp(access_scanner, 0, idcheck, check_records, check_arrest, connected_faction)
 
 //Secbot Construction
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -278,7 +278,7 @@
 					if(!rec.load_from_global(perpname))
 						msg += "<span class = 'deptradio'>ERROR:No public records found! Record creation aborted!\n</span>"
 					else
-						msg += "<span class = 'deptradio'>New record successfully created for [faction.name]!\n</span>"
+						msg += "<span class = 'deptradio'>New record successfully created for [perpname] in [faction.name] database!\n</span>"
 						faction.records.faction_records |= rec //Add to faction records
 
 				record = faction.get_record(perpname)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -270,12 +270,23 @@
 			perpname = name
 
 		if(perpname)
-			var/datum/computer_file/crew_record/R = get_crewmember_record(perpname)
-			if(R)
-				criminal = R.get_criminalStatus()
+			var/datum/world_faction/faction = get_faction(user.GetFaction())
+			if(faction)
+				var/datum/computer_file/crew_record/record
+				if(!faction.get_record(perpname))
+					var/datum/computer_file/crew_record/rec = new() //If there's no record created for them in the faction, make a new one.
+					if(!rec.load_from_global(perpname))
+						msg += "<span class = 'deptradio'>ERROR:No public records found! Record creation aborted!\n</span>"
+					else
+						msg += "<span class = 'deptradio'>New record successfully created for [faction.name]!\n</span>"
+						faction.records.faction_records |= rec //Add to faction records
 
-			msg += "<span class = 'deptradio'>Criminal status:</span> <a href='?src=\ref[src];criminal=1'>\[[criminal]\]</a>\n"
-			msg += "<span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=`'>\[View\]</a>\n"
+				record = faction.get_record(perpname)
+
+				if(record)
+					criminal = record.get_criminalStatus()
+				msg += "<span class = 'deptradio'>Criminal status:</span> <a href='?src=\ref[src];criminal=1'>\[[criminal]\]</a>\n"
+				msg += "<span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=`'>\[View\]</a>\n"
 
 	if(hasHUD(user,"medical"))
 		var/perpname = "wot"
@@ -290,12 +301,14 @@
 		else
 			perpname = src.name
 
-		var/datum/computer_file/crew_record/R = get_crewmember_record(perpname)
-		if(R)
-			medical = R.get_status()
+		var/datum/world_faction/faction = get_faction(user.GetFaction())
+		if(faction)
+			var/datum/computer_file/crew_record/R = faction.get_record(perpname)
+			if(R)
+				medical = R.get_status()
 
-		msg += "<span class = 'deptradio'>Physical status:</span> <a href='?src=\ref[src];medical=1'>\[[medical]\]</a>\n"
-		msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a>\n"
+			msg += "<span class = 'deptradio'>Physical status:</span> <a href='?src=\ref[src];medical=1'>\[[medical]\]</a>\n"
+			msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a>\n"
 
 
 	if(print_flavor_text()) msg += "[print_flavor_text()]\n"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -312,7 +312,7 @@
 /mob/proc/get_id_name(var/if_no_id = "Unknown")
 	return if_no_id
 /mob/proc/get_idcard()
-	return 
+	return
 //gets name from ID or PDA itself, ID inside PDA doesn't matter
 //Useful when player is being seen by other mobs
 /mob/living/carbon/human/get_id_name(var/if_no_id = "Unknown")
@@ -422,114 +422,131 @@
 
 	if (href_list["criminal"])
 		if(hasHUD(usr,"security"))
+			var/datum/world_faction/faction = get_faction(usr.GetFaction())
+			if(faction) //in case someone drops their ID before attempting to change status
+				if(has_access(list(core_access_security_programs), list(), usr.GetAccess(faction.uid))) //User must have security access to change criminal status.
+					var/modified = 0
+					var/perpname = "wot"
+					if(wear_id)
+						var/obj/item/weapon/card/id/I = wear_id.GetIdCard()
+						if(I)
+							perpname = I.registered_name
+						else
+							perpname = name
+					else
+						perpname = name
 
-			var/modified = 0
-			var/perpname = "wot"
-			if(wear_id)
-				var/obj/item/weapon/card/id/I = wear_id.GetIdCard()
-				if(I)
-					perpname = I.registered_name
+					var/datum/computer_file/crew_record/R = faction.get_record(perpname)
+					if(R)
+						var/setcriminal = input(usr, "Specify a new criminal status for this person.", "Security HUD", R.get_criminalStatus()) in GLOB.security_statuses as null|text
+						if(hasHUD(usr, "security") && setcriminal)
+							R.set_criminalStatus(setcriminal)
+							modified = 1
+
+							spawn()
+								BITSET(hud_updateflag, WANTED_HUD)
+								if(istype(usr,/mob/living/carbon/human))
+									var/mob/living/carbon/human/U = usr
+									U.handle_regular_hud_updates()
+								if(istype(usr,/mob/living/silicon/robot))
+									var/mob/living/silicon/robot/U = usr
+									U.handle_regular_hud_updates()
+
+					if(!modified)
+						to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
 				else
-					perpname = name
-			else
-				perpname = name
+					to_chat(usr, "<span class='warning'>Access Denied</span>")
 
-			var/datum/computer_file/crew_record/R = get_crewmember_record(perpname)
-			if(R)
-				var/setcriminal = input(usr, "Specify a new criminal status for this person.", "Security HUD", R.get_criminalStatus()) in GLOB.security_statuses as null|text
-				if(hasHUD(usr, "security") && setcriminal)
-					R.set_criminalStatus(setcriminal)
-					modified = 1
-
-					spawn()
-						BITSET(hud_updateflag, WANTED_HUD)
-						if(istype(usr,/mob/living/carbon/human))
-							var/mob/living/carbon/human/U = usr
-							U.handle_regular_hud_updates()
-						if(istype(usr,/mob/living/silicon/robot))
-							var/mob/living/silicon/robot/U = usr
-							U.handle_regular_hud_updates()
-
-			if(!modified)
-				to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
 	if (href_list["secrecord"])
 		if(hasHUD(usr,"security"))
-			var/perpname = "wot"
-			var/read = 0
+			var/datum/world_faction/faction = get_faction(usr.GetFaction())
+			if(faction)
+				if(has_access(list(core_access_security_programs), list(), usr.GetAccess(faction.uid)))
+					var/perpname = "wot"
+					var/read = 0
 
-			if(wear_id)
-				if(istype(wear_id,/obj/item/weapon/card/id))
-					perpname = wear_id:registered_name
-				else if(istype(wear_id,/obj/item/device/pda))
-					var/obj/item/device/pda/tempPda = wear_id
-					perpname = tempPda.owner
-			else
-				perpname = src.name
-			var/datum/computer_file/crew_record/E = get_crewmember_record(perpname)
-			if(E)
-				if(hasHUD(usr,"security"))
-					to_chat(usr, "<b>Name:</b> [E.get_name()]")
-					to_chat(usr, "<b>Criminal Status:</b> [E.get_criminalStatus()]")
-					to_chat(usr, "<b>Details:</b> [pencode2html(E.get_criminalStatus())]")
-					read = 1
+					if(wear_id)
+						if(istype(wear_id,/obj/item/weapon/card/id))
+							perpname = wear_id:registered_name
+						else if(istype(wear_id,/obj/item/device/pda))
+							var/obj/item/device/pda/tempPda = wear_id
+							perpname = tempPda.owner
+					else
+						perpname = src.name
+					var/datum/computer_file/crew_record/E = faction.get_record(perpname)
+					if(E)
+						if(hasHUD(usr,"security"))
+							to_chat(usr, "<b>Name:</b> [E.get_name()]")
+							to_chat(usr, "<b>Criminal Status:</b> [E.get_criminalStatus()]")
+							to_chat(usr, "<b>Details:</b> [pencode2html(E.get_criminalStatus())]")
+							read = 1
 
-			if(!read)
-				to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+					if(!read)
+						to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+				else
+					to_chat(usr, "<span class='warning'>Access Denied</span>")
+
 	if (href_list["medical"])
 		if(hasHUD(usr,"medical"))
-			var/perpname = "wot"
-			var/modified = 0
+			var/datum/world_faction/faction = get_faction(usr.GetFaction())
+			if(faction)
+				if(has_access(list(core_access_medical_programs), list(), usr.GetAccess(faction.uid)))
+					var/perpname = "wot"
+					var/modified = 0
 
-			if(wear_id)
-				if(istype(wear_id,/obj/item/weapon/card/id))
-					perpname = wear_id:registered_name
-				else if(istype(wear_id,/obj/item/device/pda))
-					var/obj/item/device/pda/tempPda = wear_id
-					perpname = tempPda.owner
-			else
-				perpname = src.name
+					if(wear_id)
+						if(istype(wear_id,/obj/item/weapon/card/id))
+							perpname = wear_id:registered_name
+					else if(istype(wear_id,/obj/item/device/pda))
+						var/obj/item/device/pda/tempPda = wear_id
+						perpname = tempPda.owner
+					else
+						perpname = src.name
 
-			var/datum/computer_file/crew_record/E = get_crewmember_record(perpname)
-			if(E)
-				var/setmedical = input(usr, "Specify a new medical status for this person.", "Medical HUD", E.get_status()) in GLOB.physical_statuses as null|text
-				if(hasHUD(usr,"medical") && setmedical)
-					E.set_status(setmedical)
-					modified = 1
+					var/datum/computer_file/crew_record/E = faction.get_record(perpname)
+					if(E)
+						var/setmedical = input(usr, "Specify a new medical status for this person.", "Medical HUD", E.get_status()) in GLOB.physical_statuses as null|text
+						if(hasHUD(usr,"medical") && setmedical)
+							E.set_status(setmedical)
+							modified = 1
 
-					spawn()
-						if(istype(usr,/mob/living/carbon/human))
-							var/mob/living/carbon/human/U = usr
-							U.handle_regular_hud_updates()
-						if(istype(usr,/mob/living/silicon/robot))
-							var/mob/living/silicon/robot/U = usr
-							U.handle_regular_hud_updates()
+							spawn()
+								if(istype(usr,/mob/living/carbon/human))
+									var/mob/living/carbon/human/U = usr
+									U.handle_regular_hud_updates()
+								if(istype(usr,/mob/living/silicon/robot))
+									var/mob/living/silicon/robot/U = usr
+									U.handle_regular_hud_updates()
 
-			if(!modified)
-				to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+					if(!modified)
+						to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
 	if (href_list["medrecord"])
 		if(hasHUD(usr,"medical"))
-			var/perpname = "wot"
-			var/read = 0
+			var/datum/world_faction/faction = get_faction(usr.GetFaction())
+			if(faction)
+				if(has_access(list(core_access_medical_programs), list(), usr.GetAccess(faction.uid)))
+					var/perpname = "wot"
+					var/read = 0
 
-			if(wear_id)
-				if(istype(wear_id,/obj/item/weapon/card/id))
-					perpname = wear_id:registered_name
-				else if(istype(wear_id,/obj/item/device/pda))
-					var/obj/item/device/pda/tempPda = wear_id
-					perpname = tempPda.owner
-			else
-				perpname = src.name
-			var/datum/computer_file/crew_record/E = get_crewmember_record(perpname)
-			if(E)
-				if(hasHUD(usr,"medical"))
-					to_chat(usr, "<b>Name:</b> [E.get_name()]")
-					to_chat(usr, "<b>Gender:</b> [E.get_sex()]")
-					to_chat(usr, "<b>Species:</b> [E.get_species()]")
-					to_chat(usr, "<b>Blood Type:</b> [E.get_bloodtype()]")
-					to_chat(usr, "<b>Details:</b> [pencode2html(E.get_medRecord())]")
-					read = 1
-			if(!read)
-				to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+					if(wear_id)
+						if(istype(wear_id,/obj/item/weapon/card/id))
+							perpname = wear_id:registered_name
+						else if(istype(wear_id,/obj/item/device/pda))
+							var/obj/item/device/pda/tempPda = wear_id
+							perpname = tempPda.owner
+					else
+						perpname = src.name
+					var/datum/computer_file/crew_record/E = get_crewmember_record(perpname)
+					if(E)
+						if(hasHUD(usr,"medical"))
+							to_chat(usr, "<b>Name:</b> [E.get_name()]")
+							to_chat(usr, "<b>Gender:</b> [E.get_sex()]")
+							to_chat(usr, "<b>Species:</b> [E.get_species()]")
+							to_chat(usr, "<b>Blood Type:</b> [E.get_bloodtype()]")
+							to_chat(usr, "<b>Details:</b> [pencode2html(E.get_medRecord())]")
+							read = 1
+					if(!read)
+						to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
 
 	if (href_list["lookitem"])
 		var/obj/item/I = locate(href_list["lookitem"])

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1028,18 +1028,20 @@
 			if(I)
 				perpname = I.registered_name
 
-		var/datum/computer_file/crew_record/E = get_crewmember_record(perpname)
-		if(E)
-			switch(E.get_criminalStatus())
-				if("Arrest")
-					holder.icon_state = "hudwanted"
-				if("Incarcerated")
-					holder.icon_state = "hudprisoner"
-				if("Parolled")
-					holder.icon_state = "hudparolled"
-				if("Released")
-					holder.icon_state = "hudreleased"
-		hud_list[WANTED_HUD] = holder
+		var/datum/world_faction/faction = get_faction(src.GetFaction())
+		if(faction)
+			var/datum/computer_file/crew_record/E = faction.get_record(perpname)
+			if(E)
+				switch(E.get_criminalStatus())
+					if("Arrest")
+						holder.icon_state = "hudwanted"
+					if("Incarcerated")
+						holder.icon_state = "hudprisoner"
+					if("Parolled")
+						holder.icon_state = "hudparolled"
+					if("Released")
+						holder.icon_state = "hudreleased"
+			hud_list[WANTED_HUD] = holder
 
 	if (  BITTEST(hud_updateflag, IMPLOYAL_HUD) \
 	   || BITTEST(hud_updateflag,  IMPCHEM_HUD) \

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -491,19 +491,19 @@ proc/is_blind(A)
 	return 1
 
 #define SAFE_PERP -50
-/mob/living/proc/assess_perp(var/obj/access_obj, var/check_access, var/auth_weapons, var/check_records, var/check_arrest)
+/mob/living/proc/assess_perp(var/obj/access_obj, var/check_access, var/auth_weapons, var/check_records, var/check_arrest, var/faction)
 	if(stat == DEAD)
 		return SAFE_PERP
 
 	return 0
 
-/mob/living/carbon/assess_perp(var/obj/access_obj, var/check_access, var/auth_weapons, var/check_records, var/check_arrest)
+/mob/living/carbon/assess_perp(var/obj/access_obj, var/check_access, var/auth_weapons, var/check_records, var/check_arrest, var/faction)
 	if(handcuffed)
 		return SAFE_PERP
 
 	return ..()
 
-/mob/living/carbon/human/assess_perp(var/obj/access_obj, var/check_access, var/auth_weapons, var/check_records, var/check_arrest)
+/mob/living/carbon/human/assess_perp(var/obj/access_obj, var/check_access, var/auth_weapons, var/check_records, var/check_arrest, var/datum/world_faction/faction)
 	var/threatcount = ..()
 	if(. == SAFE_PERP)
 		return SAFE_PERP
@@ -533,20 +533,22 @@ proc/is_blind(A)
 			threatcount += 2
 
 	if(check_records || check_arrest)
-		var/perpname = name
-		if(id)
-			perpname = id.registered_name
+		if(faction)
+			var/perpname = name
+			if(id)
+				perpname = id.registered_name
 
-		var/datum/computer_file/crew_record/CR = get_crewmember_record(perpname)
-		if(check_records && !CR && !isMonkey())
-			threatcount += 4
-
-		if(check_arrest && CR && (CR.get_criminalStatus() == GLOB.arrest_security_status))
-			threatcount += 4
+			var/datum/computer_file/crew_record/CR = faction.get_record(perpname)
+			/* Since security records are now properly factionalized, the chance of someone not having a record is pretty high.
+			if(check_records && !CR && !isMonkey())
+				threatcount += 4
+			*/
+			if(check_arrest && CR && (CR.get_criminalStatus() == GLOB.arrest_security_status))
+				threatcount += 8
 
 	return threatcount
 
-/mob/living/simple_animal/hostile/assess_perp(var/obj/access_obj, var/check_access, var/auth_weapons, var/check_records, var/check_arrest)
+/mob/living/simple_animal/hostile/assess_perp(var/obj/access_obj, var/check_access, var/auth_weapons, var/check_records, var/check_arrest, var/faction)
 	var/threatcount = ..()
 	if(. == SAFE_PERP)
 		return SAFE_PERP

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -543,6 +543,8 @@ proc/is_blind(A)
 			if(check_records && !CR && !isMonkey())
 				threatcount += 4
 			*/
+			if(perpname == "Unknown")
+				threatcount += 4
 			if(check_arrest && CR && (CR.get_criminalStatus() == GLOB.arrest_security_status))
 				threatcount += 8
 

--- a/code/modules/modular_computers/file_system/crew_record.dm
+++ b/code/modules/modular_computers/file_system/crew_record.dm
@@ -30,7 +30,7 @@ FIELD_LIST("Sex", sex, record_genders())
 FIELD_NUM("Age", age)
 
 FIELD_LIST("Status", status, GLOB.physical_statuses)
-/record_field/status/acccess_edit = access_medical
+/record_field/status/acccess_edit = core_access_medical_programs
 
 FIELD_SHORT("Species",species)
 FIELD_LIST("Branch", branch, record_branches())
@@ -38,20 +38,20 @@ FIELD_LIST("Rank", rank, record_ranks())
 
 // MEDICAL RECORDS
 FIELD_LIST("Blood Type", bloodtype, GLOB.blood_types)
-FIELD_LONG_SECURE("Medical Record", medRecord, access_medical)
+FIELD_LONG_SECURE("Medical Record", medRecord, core_access_medical_programs)
 
 // SECURITY RECORDS
-FIELD_LIST_SECURE("Criminal Status", criminalStatus, GLOB.security_statuses, access_security)
-FIELD_LONG_SECURE("Security Record", secRecord, access_security)
-FIELD_SHORT_SECURE("DNA", dna, access_security)
-FIELD_SHORT_SECURE("Fingerprint", fingerprint, access_security)
+FIELD_LIST_SECURE("Criminal Status", criminalStatus, GLOB.security_statuses, core_access_security_programs)
+FIELD_LONG_SECURE("Security Record", secRecord, core_access_security_programs)
+FIELD_SHORT_SECURE("DNA", dna, core_access_security_programs)
+FIELD_SHORT_SECURE("Fingerprint", fingerprint, core_access_security_programs)
 
 // EMPLOYMENT RECORDS
-FIELD_LONG_SECURE("Employment Record", emplRecord, access_heads)
-FIELD_SHORT_SECURE("Home System", homeSystem, access_heads)
-FIELD_SHORT_SECURE("Citizenship", citizenship, access_heads)
-FIELD_SHORT_SECURE("Faction", faction, access_heads)
-FIELD_SHORT_SECURE("Religion", religion, access_heads)
+FIELD_LONG_SECURE("Employment Record", emplRecord, core_access_command_programs)
+FIELD_SHORT_SECURE("Home System", homeSystem, core_access_command_programs)
+FIELD_SHORT_SECURE("Citizenship", citizenship, core_access_command_programs)
+FIELD_SHORT_SECURE("Faction", faction, core_access_command_programs)
+FIELD_SHORT_SECURE("Religion", religion, core_access_command_programs)
 
 // ANTAG RECORDS
 FIELD_LONG_SECURE("Exploitable Information", antagRecord, access_syndicate)


### PR DESCRIPTION
Criminal status applied with security HUDs and other future methods now properly reads from faction records, so turrets and security bots will only pew-pew at the people _their_ faction sets as criminals.
In addition, a Faction-ID check will prevent anyone unauthorized from changing criminal status, unless they steal the necessary ID.

The modular-computer records program now reads from the faction records, and far more of the fields (including security/medical/employment records and criminal status) are now available to those with the right access.