### PR TITLE
APC Terminals and Unathi Clothing fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -197,6 +197,8 @@
 	var/list/equip_adjust = list()
 	var/list/equip_overlays = list()
 
+	var/list/prone_overlay_offset = list(0,0)// amount to shift overlays when lying down
+
 	var/list/backgrounds = list() // format list("Outer World Colonist" = "blurbtext")
 
 /*

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -147,6 +147,8 @@
 		)
 	breathing_sound = 'sound/voice/lizard.ogg'
 
+	prone_overlay_offset = list(-4, -4)
+
 /datum/species/unathi/equip_survival_gear(var/mob/living/carbon/human/H)
 	..()
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H),slot_shoes)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -153,32 +153,32 @@ Please contact me on #coderbus IRC. ~Carn x
 	update_hud()		//TODO: remove the need for this
 	overlays.Cut()
 
+	var/list/visible_overlays = overlays_standing
+
 	if (icon_update)
 		if(is_cloaked())
 
 			icon = 'icons/mob/human.dmi'
 			icon_state = "blank"
 
-			for(var/entry in list(overlays_standing[R_HAND_LAYER], overlays_standing[L_HAND_LAYER]))
-				if(istype(entry, /image))
-					overlays += entry
-				else if(istype(entry, /list))
-					for(var/inner_entry in entry)
-						overlays += inner_entry
-
-			if(species.has_floating_eyes)
-				overlays |= species.get_eyes(src)
+			visible_overlays = list(visible_overlays[R_HAND_LAYER], visible_overlays[L_HAND_LAYER])
 
 		else
 			icon = stand_icon
 			icon_state = null
 
-			for(var/entry in overlays_standing)
+			var/matrix/M = matrix()
+			if(lying && (species.prone_overlay_offset[1] || species.prone_overlay_offset[2]))
+				M.Translate(species.prone_overlay_offset[1], species.prone_overlay_offset[2])
+			for(var/entry in visible_overlays)
 				if(istype(entry, /image))
-					overlays += entry
+					var/image/overlay = entry
+					overlay.transform = M
+					overlays += overlay
 				else if(istype(entry, /list))
-					for(var/inner_entry in entry)
-						overlays += inner_entry
+					for(var/image/overlay in entry)
+						overlay.transform = M
+						overlays += overlay
 			if(species.has_floating_eyes)
 				overlays |= species.get_eyes(src)
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -234,6 +234,8 @@
 		if(!loc)
 			qdel(src)
 			return
+		if(!terminal)
+			make_terminal() //This will create all the terminals for the APCs on initial map start.
 	if(loc)
 		var/area/A = src.loc.loc
 


### PR DESCRIPTION
APCs are now given a Terminal on initial map-start.
Fixed a bug where Unathi clothing was offset when laying down
(code taken from https://github.com/Baystation12/Baystation12/pull/20707)
