### PR TITLE
Healthier Spessmen

### DIFF
--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -4,8 +4,8 @@
 	icon_name = "head"
 	name = "head"
 	slot_flags = SLOT_BELT
-	max_damage = 75
-	min_broken_damage = 35
+	max_damage = 150
+	min_broken_damage = 100
 	w_class = ITEM_SIZE_NORMAL
 	body_part = HEAD
 	can_heal_overkill = 1

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -8,7 +8,7 @@
 	name = "upper body"
 	organ_tag = BP_CHEST
 	icon_name = "torso"
-	max_damage = 150
+	max_damage = 200
 	min_broken_damage = 70
 	w_class = ITEM_SIZE_HUGE //Used for dismembering thresholds, in addition to storage. Humans are w_class 6, so it makes sense that chest is w_class 5.
 	body_part = UPPER_TORSO

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -8,8 +8,8 @@
 	name = "upper body"
 	organ_tag = BP_CHEST
 	icon_name = "torso"
-	max_damage = 100
-	min_broken_damage = 35
+	max_damage = 150
+	min_broken_damage = 70
 	w_class = ITEM_SIZE_HUGE //Used for dismembering thresholds, in addition to storage. Humans are w_class 6, so it makes sense that chest is w_class 5.
 	body_part = UPPER_TORSO
 	can_heal_overkill = 1

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -9,7 +9,7 @@
 	var/beat_sound = 'sound/effects/singlebeat.ogg'
 	var/tmp/next_blood_squirt = 0
 	relative_size = 15
-	max_damage = 45
+	max_damage = 55
 	var/open
 
 /obj/item/organ/internal/heart/die()

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -5,9 +5,9 @@
 	w_class = ITEM_SIZE_SMALL
 	organ_tag = BP_LIVER
 	parent_organ = BP_GROIN
-	min_bruised_damage = 25
-	min_broken_damage = 45
-	max_damage = 70
+	min_bruised_damage = 50
+	min_broken_damage = 80
+	max_damage = 90
 	relative_size = 60
 	scarring_effect = 4
 

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -5,9 +5,9 @@
 	organ_tag = BP_LUNGS
 	parent_organ = BP_CHEST
 	w_class = ITEM_SIZE_NORMAL
-	min_bruised_damage = 25
-	min_broken_damage = 45
-	max_damage = 70
+	min_bruised_damage = 50
+	min_broken_damage = 70
+	max_damage = 90
 	relative_size = 60
 	scarring_effect = 4
 


### PR DESCRIPTION
Buffs the health of the Head, Chest, Lungs, Liver, and Heart to more realistic degrees.
It does not modify internal hemorrhaging or damage over time due to broken bones.
The head and chest are now EXTREMELY difficult to break or shatter, especially compared to the arms, feet, and hands.

In short, you will still take damage over time from internal injuries and broken bones, which will accumulate, and de-limbing but not dying is now easier.