### PR TITLE
Makes shuttle engines not banish uranium stacks to the void

### DIFF
--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -110,11 +110,7 @@
 	component_parts += new /obj/item/weapon/stock_parts/capacitor(src)
 	component_parts += new /obj/item/weapon/stock_parts/capacitor(src)
 	component_parts += new /obj/item/stack/cable_coil(src, 30)
-	component_parts += new /obj/item/stack/material/uranium(src)
-	component_parts += new /obj/item/stack/material/uranium(src)
-	component_parts += new /obj/item/stack/material/uranium(src)
-	component_parts += new /obj/item/stack/material/uranium(src)
-	component_parts += new /obj/item/stack/material/uranium(src)
+	component_parts += new /obj/item/stack/material/uranium(src, 5)
 	RefreshParts()
 
 /obj/machinery/shuttleengine/attackby(var/obj/O as obj, var/mob/user as mob)


### PR DESCRIPTION
Another simple self explanatory bug fix. Was asking for stacks of uranium rather than sheets.
<!-- 
!!IMPORTANT!!
Changes must be reviewed and approved by a developer before being merged.

If a developer has approved your PR, any other developer may immediately merge it, or the same developer may merge it after 24 hours.

A developer may not merge their own PR without the approval of two other developers.

Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
