### PR TITLE
Removes Mind Role Restrictions in some cases

### DIFF
--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -42,6 +42,11 @@ var/const/EXTRA_COST_FACTOR = 1
 	path = /obj/item/device/flashlight
 	category = "General"
 
+/datum/autolathe/recipe/butcherknife
+	name = "butcher's knife
+	path = /obj/item/weapon/material/knife/butch
+	category = "General"
+
 /datum/autolathe/recipe/maglight
 	name = "maglight"
 	path = /obj/item/device/flashlight/maglight

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -42,11 +42,6 @@ var/const/EXTRA_COST_FACTOR = 1
 	path = /obj/item/device/flashlight
 	category = "General"
 
-/datum/autolathe/recipe/butcherknife
-	name = "butcher's knife
-	path = /obj/item/weapon/material/knife/butch
-	category = "General"
-
 /datum/autolathe/recipe/maglight
 	name = "maglight"
 	path = /obj/item/device/flashlight/maglight

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -333,9 +333,6 @@
 
 /obj/item/weapon/paper/attackby(obj/item/weapon/P as obj, mob/user as mob)
 	..()
-	var/clown = 0
-	if(user.mind && (user.mind.assigned_role == "Clown"))
-		clown = 1
 
 	if(istype(P, /obj/item/weapon/tape_roll))
 		var/obj/item/weapon/tape_roll/tape = P
@@ -397,11 +394,6 @@
 		offset_y += y
 		stampoverlay.pixel_x = x
 		stampoverlay.pixel_y = y
-
-		if(istype(P, /obj/item/weapon/stamp/clown))
-			if(!clown)
-				to_chat(user, "<span class='notice'>You are totally unable to use the stamp. HONK!</span>")
-				return
 
 		if(!ico)
 			ico = new

--- a/code/modules/projectiles/guns/projectile/detective.dm
+++ b/code/modules/projectiles/guns/projectile/detective.dm
@@ -24,14 +24,11 @@
 /obj/item/weapon/gun/projectile/colt/detective/verb/rename_gun()
 	set name = "Name Gun"
 	set category = "Object"
-	set desc = "Rename your gun. If you're the detective."
+	set desc = "Rename your gun."
 
 	var/mob/M = usr
 	if(!M.mind)	return 0
 	if(M.incapacitated()) return 0
-	if(!M.mind.assigned_role == "Detective")
-		to_chat(M, "<span class='notice'>You don't feel cool enough to name this gun, chump.</span>")
-		return 0
 
 	var/input = sanitizeSafe(input("What do you want to name the gun?","Rename gun"), MAX_NAME_LEN)
 

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -56,13 +56,10 @@
 /obj/item/weapon/gun/projectile/revolver/detective/verb/rename_gun()
 	set name = "Name Gun"
 	set category = "Object"
-	set desc = "Click to rename your gun. If you're the detective."
+	set desc = "Click to rename your gun."
 
 	var/mob/M = usr
 	if(!M.mind)	return 0
-	if(!M.mind.assigned_role == "Detective")
-		to_chat(M, "<span class='notice'>You don't feel cool enough to name this gun, chump.</span>")
-		return 0
 
 	var/input = sanitizeSafe(input("What do you want to name the gun?", ,""), MAX_NAME_LEN)
 


### PR DESCRIPTION
<!-- 
!!IMPORTANT!!
Changes must be reviewed and approved by a developer before being merged.

If a developer has approved your PR, any other developer may immediately merge it, or the same developer may merge it after 24 hours.

A developer may not merge their own PR without the approval of two other developers.

Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
I removed the mind.assigned.role restrictions on using the clown stamp and renaming the .38 revolver, because persistence doesn't really use mind roles. I considered doing the same thing for the Chaplain requirement making holy water with a bible and water tank, but I didn't really know if there is anything planned in that regard so I left it as is.

Also, fixes #480 