### PR TITLE
Freedom Ain't Free

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -57,7 +57,7 @@ obj/item/weapon/gun/energy/retro
 	w_class = ITEM_SIZE_NORMAL
 	projectile_type = /obj/item/projectile/beam
 	fire_delay = 15 //old technology, and a pistol
-/*
+
 /obj/item/weapon/gun/energy/captain
 	name = "antique laser gun"
 	icon_state = "caplaser"
@@ -71,7 +71,7 @@ obj/item/weapon/gun/energy/retro
 	max_shots = 5 //to compensate a bit for self-recharging
 	one_hand_penalty = 1 //a little bulky
 	self_recharge = 1
-*/
+
 /obj/item/weapon/gun/energy/lasercannon
 	name = "laser cannon"
 	desc = "With the laser cannon, the lasing medium is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core. This incredible technology may help YOU achieve high excitation rates with small laser volumes!"
@@ -95,7 +95,7 @@ obj/item/weapon/gun/energy/retro
 	recharge_time = 10
 	accuracy = 0 //mounted laser cannons don't need any help, thanks
 	one_hand_penalty = 0
-/*
+
 /obj/item/weapon/gun/energy/xray
 	name = "x-ray laser carbine"
 	desc = "A high-power laser gun capable of emitting concentrated x-ray blasts, that are able to penetrate laser-resistant armor much more readily than standard photonic beams."
@@ -148,7 +148,7 @@ obj/item/weapon/gun/energy/retro
 	set popup_menu = 1
 
 	toggle_scope(usr, 2.0)
-*/
+
 ////////Laser Tag////////////////////
 
 /obj/item/weapon/gun/energy/lasertag

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -35,7 +35,7 @@
 	name = "mounted energy gun"
 	self_recharge = 1
 	use_external_power = 1
-/*
+
 /obj/item/weapon/gun/energy/gun/nuclear
 	name = "advanced energy gun"
 	desc = "An energy gun with an experimental miniaturized reactor."
@@ -100,4 +100,3 @@
 	new_overlays += get_mode_overlay()
 
 	overlays = new_overlays
-*/

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -118,7 +118,7 @@
 	desc = "A custom-built weapon of some kind."
 	icon_state = "xray"
 	projectile_type = /obj/item/projectile/beam/mindflayer
-/*
+
 /obj/item/weapon/gun/energy/toxgun
 	name = "phoron pistol"
 	desc = "A specialized firearm designed to fire lethal bolts of phoron."
@@ -126,7 +126,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_COMBAT = 5, TECH_PHORON = 4)
 	projectile_type = /obj/item/projectile/energy/phoron
-*/
+
 /* Staves */
 
 /obj/item/weapon/gun/energy/staff
@@ -199,11 +199,11 @@ obj/item/weapon/gun/energy/staff/focus
 	var/toolspeed = 0.7 //plasmacutters can be used as welders for a few things, and are faster than standard welders
 	fire_sound = 'sound/weapons/pulse.ogg'
 	fire_sound_text = "plasma blast"
-	projectile_type= /obj/item/projectile/plasma
+	projectile_type = /obj/item/projectile/plasma
 	charge_cost = 10 //How much energy is needed to fire.
 	max_shots = 30 //Determines the capacity of the weapon's power cell. Specifying a cell_type overrides this value.
-	sharp=1
-	edge=1
+	sharp = 1
+	edge = 1
 
 
 /obj/item/weapon/gun/energy/plasmacutter/attackby(obj/item/A, mob/user)

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -19,7 +19,7 @@
 		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=4,    one_hand_penalty=1, burst_accuracy=list(0,-1,-1),       dispersion=list(0.0, 0.6, 1.0)),
 		list(mode_name="short bursts",   burst=5, fire_delay=null, move_delay=4,    one_hand_penalty=2, burst_accuracy=list(0,-1,-1,-1,-2), dispersion=list(0.6, 0.6, 1.0, 1.0, 1.2)),
 		)
-/*
+
 /obj/item/weapon/gun/projectile/automatic/machine_pistol
 	name = ".45 machine pistol"
 	desc = "An uncommon machine pistol, sometimes refered to as an 'uzi' by the backwater spacers it is often associated with, though its origins have been lost to time. Uses .45 rounds."
@@ -106,7 +106,7 @@
 	icon_state = (ammo_magazine)? "arifle" : "arifle-empty"
 	wielded_item_state = (ammo_magazine)? "arifle-wielded" : "arifle-wielded-empty"
 	..()
-*/
+
 /obj/item/weapon/gun/projectile/automatic/wt550
 	name = "9mm machine pistol"
 	desc = "The W-T 550 Saber is a cheap self-defense weapon, mass-produced by Ward-Takahashi for paramilitary and private use. Uses 9mm rounds."
@@ -135,7 +135,7 @@
 	else
 		icon_state = "wt550"
 	return
-/*
+
 /obj/item/weapon/gun/projectile/automatic/z8
 	name = "bullpup assault rifle"
 	desc = "The Z8 Bulldog is an older model bullpup carbine, made by the now defunct Zendai Foundries. Uses armor piercing 7.62mm rounds. Makes you feel like a space marine when you hold it."
@@ -284,4 +284,3 @@
 		to_chat(user, "<span class='warning'>You need to open the cover to unload [src].</span>")
 		return
 	..()
-*/

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -56,7 +56,7 @@
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/c45m
 	allowed_magazines = /obj/item/ammo_magazine/c45m
-/*
+
 /obj/item/weapon/gun/projectile/magnum_pistol
 	name = ".50 magnum pistol"
 	desc = "A robust handgun that uses .50 AE ammo."
@@ -94,7 +94,7 @@
 		icon_state = "gyropistolloaded"
 	else
 		icon_state = "gyropistol"
-*/
+
 /obj/item/weapon/gun/projectile/pistol
 	name = "holdout pistol"
 	desc = "The Lumoco Arms P3 Whisper. A small, easily concealable gun. Uses 9mm rounds."

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -40,7 +40,7 @@
 		chambered = AC
 
 	update_icon()
-/*
+
 /obj/item/weapon/gun/projectile/shotgun/pump/combat
 	name = "combat shotgun"
 	desc = "Built for close quarters combat, the Hephaestus Industries KS-40 is widely regarded as a weapon of choice for repelling boarders."
@@ -50,7 +50,7 @@
 	max_shells = 7 //match the ammo box capacity, also it can hold a round in the chamber anyways, for a total of 8.
 	ammo_type = /obj/item/ammo_casing/shotgun
 	one_hand_penalty = 3 //a little heavier than the regular shotgun
-*/
+
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel
 	name = "double-barreled shotgun"
 	desc = "A true classic."

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -163,7 +163,7 @@
 	check_armour = "energy"
 	sharp = 1
 	edge = 1
-	damage = 35
+	damage = 45
 	var/pressure_decrease_active = FALSE
 	var/pressure_decrease = 0.25
 	kill_count=15

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -552,7 +552,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 3000, "silver" = 2000, "gold" = 2000, "diamond" = 6000)
 	build_path = /obj/item/weapon/gun/energy/laser
 	sort_string = "TAAAB"
-/*
+
 /datum/design/item/weapon/nuclear_gun
 	id = "nuclear_gun"
 	desc = "Self-recharging energy weapon powered by a nuclear core."
@@ -575,7 +575,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000, "uranium" = 1000, "phoron" = 6000)
 	build_path = /obj/item/weapon/gun/energy/toxgun
 	sort_string = "TAAAD"
-*/
+
 /datum/design/item/weapon/decloner
 	id = "decloner"
 	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
@@ -589,14 +589,14 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 8000, "silver" = 2000, "diamond" = 1000)
 	build_path = /obj/item/weapon/gun/projectile/automatic/wt550
 	sort_string = "TAABA"
-/*
+
 /datum/design/item/weapon/smg
 	id = "smg"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
 	materials = list(DEFAULT_WALL_MATERIAL = 8000, "silver" = 2000, "diamond" = 1000)
 	build_path = /obj/item/weapon/gun/projectile/automatic
 	sort_string = "TAABA"
-*/
+
 /datum/design/item/weapon/ammo_9mm
 	id = "ammo_9mm"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
@@ -2466,7 +2466,7 @@ CIRCUITS BELOW
 	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 10000)
 	build_path = /obj/item/disk/integrated_circuit/upgrade/advanced
 	sort_string = "WCLAD"
-	
+
 /datum/design/item/integrated_printer_upgrade_clone
 	name = "Integrated Circuit Printer Clone Disk"
 	desc = "This disk allows for integrated circuit printers to copy and clone designs instantaneously."

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -552,7 +552,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 3000, "silver" = 2000, "gold" = 2000, "diamond" = 6000)
 	build_path = /obj/item/weapon/gun/energy/laser
 	sort_string = "TAAAB"
-
+/*
 /datum/design/item/weapon/nuclear_gun
 	id = "nuclear_gun"
 	desc = "Self-recharging energy weapon powered by a nuclear core."
@@ -568,7 +568,7 @@ other types of metals and chemistry for reagents).
 	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 1000, "silver" = 2000, "diamond" = 6000)
 	build_path = /obj/item/weapon/gun/energy/lasercannon
 	sort_string = "TAAAC"
-
+*/
 /datum/design/item/weapon/phoronpistol
 	id = "ppistol"
 	req_tech = list(TECH_COMBAT = 5, TECH_PHORON = 4)

--- a/code/modules/research/mechfab_designs.dm
+++ b/code/modules/research/mechfab_designs.dm
@@ -525,12 +525,12 @@
 	name = "Engineering Chassis: Outdated Engineer"
 	id = "borg_chassis_antique"
 	build_path = /obj/item/borg/chassis_mod/engineering/antique
-	
+
 /datum/design/item/robot_upgrade/chassis/landmate
 	name = "Engineering Chassis: Landmate Model"
 	id = "borg_chassis_landmate"
 	build_path = /obj/item/borg/chassis_mod/engineering/landmate
-	
+
 /datum/design/item/robot_upgrade/chassis/treads
 	name = "Engineering Chassis: Treaded Landmate"
 	id = "borg_chassis_landmatetread"
@@ -553,12 +553,12 @@
 	name = "Janitor Chassis: Bucket-head Janitor"
 	id = "borg_chassis_buckethead"
 	build_path = /obj/item/borg/chassis_mod/janitor/buckethead
-	
+
 /datum/design/item/robot_upgrade/chassis/mopgearrex
 	name = "Janitor Chassis: MOP GEAR R.E.X"
 	id = "borg_chassis_rex"
 	build_path = /obj/item/borg/chassis_mod/janitor/mopgearrex
-	
+
 /datum/design/item/robot_upgrade/chassis/bipedaljanitor
 	name = "Janitor Chassis: Bipedal Janitor Cyborg"
 	id = "borg_chassis_janitbiped"
@@ -571,16 +571,16 @@
 	name = "Research Chassis: Science Droid"
 	id = "borg_chassis_scidroid"
 	build_path = /obj/item/borg/chassis_mod/science/sciencedroid
-	
+
 /datum/design/item/robot_upgrade/chassis/scienceeyebot
 	name = "Research Chassis: Science Eyebot"
 	id = "borg_chassis_scieye"
-	build_path = /obj/item/borg/chassis_mod/science/scienceeyebot	
-	
+	build_path = /obj/item/borg/chassis_mod/science/scienceeyebot
+
 ////////////////////////////////////////////////////
 //////////////////////MODULE CHIPS//////////////////
 /////////////////////////////////////////////////////
-	
+
 /datum/design/item/robot_upgrade/module
 	category = "Cyborg Modules"
 	materials = list(DEFAULT_WALL_MATERIAL = 25000, "phoron" = 10000, "gold" = 1000, "silver" = 1000)
@@ -589,27 +589,27 @@
 /datum/design/item/robot_upgrade/module/surgeon
 	name = "Module Chip: Medical Surgeon"
 	id = "borg_module_surgeon"
-	build_path = /obj/item/borg/module_chip/medical/surgeon	
+	build_path = /obj/item/borg/module_chip/medical/surgeon
 	materials = list(DEFAULT_WALL_MATERIAL = 25000, "glass" = 10000, "phoron" = 5000, "gold" = 2000, "silver" = 2000)
-	
+
 /datum/design/item/robot_upgrade/module/crisis
 	name = "Module Chip: Medical Crisis"
 	id = "borg_module_crisis"
 	build_path = /obj/item/borg/module_chip/medical
 	materials = list(DEFAULT_WALL_MATERIAL = 25000, "glass" = 10000, "phoron" = 5000, "gold" = 2000, "silver" = 2000)
-		
+
 /datum/design/item/robot_upgrade/module/engineering
 	name = "Module Chip: Engineering"
 	id = "borg_module_engineering"
 	build_path = /obj/item/borg/module_chip/engineering
 	materials = list(DEFAULT_WALL_MATERIAL = 25000, "glass" = 10000, "phoron" = 5000, "gold" = 2000, "silver" = 2000)
-	
+
 /datum/design/item/robot_upgrade/module/security
 	name = "Module Chip: Security"
 	id = "borg_module_security"
 	build_path = /obj/item/borg/module_chip/security
 	materials = list(DEFAULT_WALL_MATERIAL = 25000, "glass" = 10000, "phoron" = 5000, "gold" = 2000, "silver" = 2000)
-	
+
 /datum/design/item/robot_upgrade/module/mining
 	name = "Module Chip: Mining"
 	id = "borg_module_mining"
@@ -633,16 +633,16 @@
 	id = "borg_module_clerical"
 	build_path = /obj/item/borg/module_chip/clerical
 	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 5000, "phoron" = 1000)
-	
+
 /datum/design/item/robot_upgrade/module/service
 	name = "Module Chip: Service"
 	id = "borg_module_service"
 	build_path = /obj/item/borg/module_chip/service
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 5000, "phoron" = 1000)	
+	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 5000, "phoron" = 1000)
 
 
 
-	
+
 /datum/design/item/mecha_tracking
 	name = "Exosuit tracking beacon"
 	build_type = MECHFAB
@@ -736,26 +736,26 @@
 	id = "mech_scattershot"
 	req_tech = list(TECH_COMBAT = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot
-/*
+
 /datum/design/item/mecha/weapon/laser
 	name = "CH-PS \"Immolator\" laser"
 	id = "mech_laser"
 	req_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
-*/
+
 /datum/design/item/mecha/weapon/laser_rigged
 	name = "Jury-rigged welder-laser"
 	desc = "Allows for the construction of a welder-laser assembly package for non-combat exosuits."
 	id = "mech_laser_rigged"
 	req_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 2)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/riggedlaser
-/*
+
 /datum/design/item/mecha/weapon/laser_heavy
 	name = "CH-LC \"Solaris\" laser cannon"
 	id = "mech_laser_heavy"
 	req_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
-*/
+
 /datum/design/item/mecha/weapon/ion
 	name = "mkIV ion heavy cannon"
 	id = "mech_ion"


### PR DESCRIPTION
<!-- 
!!IMPORTANT!!
Changes must be reviewed and approved by a developer before being merged.

If a developer has approved your PR, any other developer may immediately merge it, or the same developer may merge it after 24 hours.

A developer may not merge their own PR without the approval of two other developers.

Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
This PR effectively reverts all changes made in the infamous #243

I think the original points and reasons for the gun reversion has passed, it's time for the crew, of any faction out there, to cope with the existence of firearms. With the recent Mining changes, an undo of the plasma cutter debuff adding along with #243 also works well being removed. I know there may be some hesitance with the re-addition of AEGs, but I'm confidant a viable rework for it can be made before it becomes an endemic issue as in the last iteration.

https://i2.kym-cdn.com/photos/images/facebook/000/976/859/0bf.png