### PR TITLE
Can't trust players with Supermatters

### DIFF
--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -178,14 +178,6 @@
 	containername = "\improper shield generator construction kit crate"
 	access = core_access_engineering_programs
 
-/decl/hierarchy/supply_pack/engineering/smbig
-	name = "Supermatter Core (CAUTION)"
-	contains = list(/obj/machinery/power/supermatter)
-	cost = 150
-	containertype = /obj/structure/closet/crate/secure/large/phoron
-	containername = "\improper Supermatter crate (CAUTION)"
-	access = core_access_engineering_programs
-
 /decl/hierarchy/supply_pack/engineering/fueltank
 	name = "Fuel tank crate"
 	contains = list(/obj/structure/reagent_dispensers/fueltank)


### PR DESCRIPTION
Removes Supermatter crates. Players who want to create SM engines can ahelp.