### PR TITLE
Edits module cost values, fixes Security borgs spawning with no modules, and adds standard borg.

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -21,6 +21,26 @@
 	R.chassis_mod = src
 	return 1
 
+/obj/item/borg/chassis_mod/standard/droid
+	name = "Standard Chassis: Droid"
+	module_type = /obj/item/weapon/robot_module/standard
+	chassis_type = "droid"
+
+/obj/item/borg/chassis_mod/standard/old
+	name = "Standard Chassis: Old"
+	module_type = /obj/item/weapon/robot_module/standard
+	chassis_type = "robot_old"
+
+/obj/item/borg/chassis_mod/standard/drone
+	name = "Standard Chassis: Drone"
+	module_type = /obj/item/weapon/robot_module/standard
+	chassis_type = "drone-standard"
+
+/obj/item/borg/chassis_mod/standard/eyebot
+	name = "Standard Chassis: Eyebot"
+	module_type = /obj/item/weapon/robot_module/eyebot
+	chassis_type = "eyebot-stand"
+
 /obj/item/borg/chassis_mod/service/waitress
 	name = "Service/Clerical Chassis: Waitress"
 	module_type = /obj/item/weapon/robot_module/clerical
@@ -201,6 +221,11 @@
 	installed = 1
 	return 1
 
+/obj/item/borg/module_chip/standard
+	name = "Standard Module."
+	desc = "Contains tools and supplies for a standard cyborg."
+	module_type = /obj/item/weapon/robot_module/standard
+	default_icon = "robot"
 /obj/item/borg/module_chip/medical/surgeon
 	name = "Surgeon Module."
 	desc = "Contains tools and supplies for a surgeon class medical cyborg."

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -182,14 +182,35 @@ var/global/list/robot_modules = list(
 					"Doot" = "eyebot-standard"
 				  )
 	module_type = "standard"
+	robo_icon_state = "robot"
 /obj/item/weapon/robot_module/standard/New()
 	src.modules += new /obj/item/device/flash(src)
 	src.modules += new /obj/item/weapon/melee/baton/loaded(src)
 	src.modules += new /obj/item/weapon/extinguisher(src)
+	src.modules += new /obj/item/weapon/pickaxe(src)
+	src.modules += new /obj/item/weapon/soap(src)
 	src.modules += new /obj/item/weapon/wrench(src)
 	src.modules += new /obj/item/weapon/crowbar(src)
+	src.modules += new /obj/item/weapon/weldingtool/largetank(src)
+	src.modules += new /obj/item/weapon/reagent_containers/borghypo/standard(src)
 	src.modules += new /obj/item/device/healthanalyzer(src)
 	src.emag = new /obj/item/weapon/melee/energy/sword(src)
+
+	var/datum/matter_synth/metal = new /datum/matter_synth/metal(40000)
+	synths += metal
+
+	var/obj/item/stack/material/cyborg/steel/M = new (src)
+	M.synths = list(metal)
+	src.modules += M
+
+	var/obj/item/stack/rods/cyborg/R = new /obj/item/stack/rods/cyborg(src)
+	R.synths = list(metal)
+	src.modules += R
+
+	var/obj/item/stack/tile/floor/cyborg/S = new /obj/item/stack/tile/floor/cyborg(src)
+	S.synths = list(metal)
+	src.modules += S
+
 	..()
 
 /obj/item/weapon/robot_module/medical
@@ -317,7 +338,7 @@ var/global/list/robot_modules = list(
 
 	..()
 
-	
+
 /obj/item/weapon/robot_module/engineering
 	name = "engineering robot module"
 	channels = list("Engineering" = 1)

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -17,6 +17,10 @@
 	var/list/reagent_volumes = list()
 	var/list/reagent_names = list()
 
+/obj/item/weapon/reagent_containers/borghypo/standard
+	desc = "An advanced chemical synthesizer and injection system, this one only appears to dispense inaprovaline."
+	reagent_ids = list(/datum/reagent/inaprovaline)
+
 /obj/item/weapon/reagent_containers/borghypo/surgeon
 	reagent_ids = list(/datum/reagent/bicaridine, /datum/reagent/dexalin, /datum/reagent/tramadol)
 

--- a/code/modules/research/mechfab_designs.dm
+++ b/code/modules/research/mechfab_designs.dm
@@ -583,7 +583,7 @@
 
 ////////////////////////////////////////////////////
 //////////////////////MODULE CHIPS//////////////////
-/////////////////////////////////////////////////////
+////////////////////////////////////////////////////
 
 /datum/design/item/robot_upgrade/module
 	category = "Cyborg Modules"
@@ -611,7 +611,7 @@
 /datum/design/item/robot_upgrade/module/security
 	name = "Module Chip: Security"
 	id = "borg_module_security"
-	build_path = /obj/item/borg/module_chip/security
+	build_path = /obj/item/borg/module_chip/security/general
 	materials = list(DEFAULT_WALL_MATERIAL = 25000, "glass" = 10000, "phoron" = 5000, "gold" = 2000, "silver" = 2000)
 
 /datum/design/item/robot_upgrade/module/mining

--- a/code/modules/research/mechfab_designs.dm
+++ b/code/modules/research/mechfab_designs.dm
@@ -316,6 +316,10 @@
 	time = 60
 	materials = list(DEFAULT_WALL_MATERIAL = 50000, "uranium" = 10000)
 
+///////////////////////////////////
+////////// Roboot Upgrade /////////
+///////////////////////////////////
+
 /datum/design/item/robot_upgrade
 	build_type = MECHFAB
 	time = 12
@@ -365,7 +369,7 @@
 	name = "Jetpack module"
 	desc = "A carbon dioxide jetpack suitable for low-gravity mining operations."
 	id = "borg_jetpack_module"
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "phoron" = 15000, "uranium" = 20000)
+	materials = list(DEFAULT_WALL_MATERIAL = 10000, "phoron" = 5000, "uranium" = 20000)
 	build_path = /obj/item/borg/upgrade/jetpack
 
 /datum/design/item/robot_upgrade/rcd
@@ -380,7 +384,7 @@
 	desc = "Allows for the construction of lethal upgrades for cyborgs."
 	id = "borg_syndicate_module"
 	req_tech = list(TECH_COMBAT = 4, TECH_ILLEGAL = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 15000, "diamond" = 10000)
+	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 15000, "phoron" = 1000, "diamond" = 10000)
 	build_path = /obj/item/borg/upgrade/syndicate
 
 // PERSISTENT ROBOT UPGRADES
@@ -391,7 +395,7 @@
 ////////////////////////////////////
 /datum/design/item/robot_upgrade/chassis
 	category = "Chassis Mods"
-	materials = list(DEFAULT_WALL_MATERIAL = 6000, "phoron" = 5000, "glass" = 6000)
+	materials = list(DEFAULT_WALL_MATERIAL = 6000, "silver" = 5000, "glass" = 6000)
 	desc = "A chassis mod that can be installed in a cyborg to allow it to change its appearance. It must be using the correct module."
 
 //////////////
@@ -525,12 +529,12 @@
 	name = "Engineering Chassis: Outdated Engineer"
 	id = "borg_chassis_antique"
 	build_path = /obj/item/borg/chassis_mod/engineering/antique
-	
+
 /datum/design/item/robot_upgrade/chassis/landmate
 	name = "Engineering Chassis: Landmate Model"
 	id = "borg_chassis_landmate"
 	build_path = /obj/item/borg/chassis_mod/engineering/landmate
-	
+
 /datum/design/item/robot_upgrade/chassis/treads
 	name = "Engineering Chassis: Treaded Landmate"
 	id = "borg_chassis_landmatetread"
@@ -553,12 +557,12 @@
 	name = "Janitor Chassis: Bucket-head Janitor"
 	id = "borg_chassis_buckethead"
 	build_path = /obj/item/borg/chassis_mod/janitor/buckethead
-	
+
 /datum/design/item/robot_upgrade/chassis/mopgearrex
 	name = "Janitor Chassis: MOP GEAR R.E.X"
 	id = "borg_chassis_rex"
 	build_path = /obj/item/borg/chassis_mod/janitor/mopgearrex
-	
+
 /datum/design/item/robot_upgrade/chassis/bipedaljanitor
 	name = "Janitor Chassis: Bipedal Janitor Cyborg"
 	id = "borg_chassis_janitbiped"
@@ -571,16 +575,16 @@
 	name = "Research Chassis: Science Droid"
 	id = "borg_chassis_scidroid"
 	build_path = /obj/item/borg/chassis_mod/science/sciencedroid
-	
+
 /datum/design/item/robot_upgrade/chassis/scienceeyebot
 	name = "Research Chassis: Science Eyebot"
 	id = "borg_chassis_scieye"
-	build_path = /obj/item/borg/chassis_mod/science/scienceeyebot	
-	
+	build_path = /obj/item/borg/chassis_mod/science/scienceeyebot
+
 ////////////////////////////////////////////////////
 //////////////////////MODULE CHIPS//////////////////
 /////////////////////////////////////////////////////
-	
+
 /datum/design/item/robot_upgrade/module
 	category = "Cyborg Modules"
 	materials = list(DEFAULT_WALL_MATERIAL = 25000, "phoron" = 10000, "gold" = 1000, "silver" = 1000)
@@ -589,32 +593,32 @@
 /datum/design/item/robot_upgrade/module/surgeon
 	name = "Module Chip: Medical Surgeon"
 	id = "borg_module_surgeon"
-	build_path = /obj/item/borg/module_chip/medical/surgeon	
-	materials = list(DEFAULT_WALL_MATERIAL = 25000, "glass" = 10000, "phoron" = 5000, "gold" = 2000, "silver" = 2000)
-	
+	build_path = /obj/item/borg/module_chip/medical/surgeon
+	materials = list(DEFAULT_WALL_MATERIAL = 25000, "glass" = 10000, "phoron" = 500, "gold" = 2000, "silver" = 3000)
+
 /datum/design/item/robot_upgrade/module/crisis
 	name = "Module Chip: Medical Crisis"
 	id = "borg_module_crisis"
 	build_path = /obj/item/borg/module_chip/medical
-	materials = list(DEFAULT_WALL_MATERIAL = 25000, "glass" = 10000, "phoron" = 5000, "gold" = 2000, "silver" = 2000)
-		
+	materials = list(DEFAULT_WALL_MATERIAL = 25000, "glass" = 10000, "phoron" = 500, "gold" = 2000, "silver" = 3000)
+
 /datum/design/item/robot_upgrade/module/engineering
 	name = "Module Chip: Engineering"
 	id = "borg_module_engineering"
 	build_path = /obj/item/borg/module_chip/engineering
-	materials = list(DEFAULT_WALL_MATERIAL = 25000, "glass" = 10000, "phoron" = 5000, "gold" = 2000, "silver" = 2000)
-	
+	materials = list(DEFAULT_WALL_MATERIAL = 25000, "glass" = 10000, "phoron" = 500, "gold" = 3000, "silver" = 2000)
+
 /datum/design/item/robot_upgrade/module/security
 	name = "Module Chip: Security"
 	id = "borg_module_security"
 	build_path = /obj/item/borg/module_chip/security
 	materials = list(DEFAULT_WALL_MATERIAL = 25000, "glass" = 10000, "phoron" = 5000, "gold" = 2000, "silver" = 2000)
-	
+
 /datum/design/item/robot_upgrade/module/mining
 	name = "Module Chip: Mining"
 	id = "borg_module_mining"
 	build_path = /obj/item/borg/module_chip/mining
-	materials = list(DEFAULT_WALL_MATERIAL = 15000, "glass" = 5000, "phoron" = 2000, "gold" = 500, "silver" = 500)
+	materials = list(DEFAULT_WALL_MATERIAL = 15000, "glass" = 5000, "uranium" = 500)
 
 /datum/design/item/robot_upgrade/module/research
 	name = "Module Chip: Research"
@@ -626,23 +630,23 @@
 	name = "Module Chip: Janitor"
 	id = "borg_module_janitor"
 	build_path = /obj/item/borg/module_chip/janitor
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 5000, "phoron" = 1000)
+	materials = list(DEFAULT_WALL_MATERIAL = 12000, "glass" = 6000, "gold" = 500, "silver" = 500)
 
 /datum/design/item/robot_upgrade/module/clerical
 	name = "Module Chip: Clerical"
 	id = "borg_module_clerical"
 	build_path = /obj/item/borg/module_chip/clerical
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 5000, "phoron" = 1000)
-	
+	materials = list(DEFAULT_WALL_MATERIAL = 12000, "glass" = 6000, "gold" = 500, "silver" = 500)
+
 /datum/design/item/robot_upgrade/module/service
 	name = "Module Chip: Service"
 	id = "borg_module_service"
 	build_path = /obj/item/borg/module_chip/service
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 5000, "phoron" = 1000)	
+	materials = list(DEFAULT_WALL_MATERIAL = 12000, "glass" = 6000, "gold" = 500, "silver" = 500)
 
 
 
-	
+
 /datum/design/item/mecha_tracking
 	name = "Exosuit tracking beacon"
 	build_type = MECHFAB

--- a/code/modules/research/mechfab_designs.dm
+++ b/code/modules/research/mechfab_designs.dm
@@ -399,8 +399,30 @@
 	desc = "A chassis mod that can be installed in a cyborg to allow it to change its appearance. It must be using the correct module."
 
 //////////////
-// Service/Clerical
+// Standard
 
+/datum/design/item/robot_upgrade/chassis/droid
+	name = "Standard Chassis: Droid"
+	id = "borg_chassis_droid"
+	build_path = /obj/item/borg/chassis_mod/standard/droid
+
+/datum/design/item/robot_upgrade/chassis/old
+	name = "Standard Chassis: Bipedal Standard"
+	id = "borg_chassis_old"
+	build_path = /obj/item/borg/chassis_mod/standard/old
+
+/datum/design/item/robot_upgrade/chassis/drone
+	name = "Standard Chassis: Drone"
+	id = "borg_chassis_drone"
+	build_path = /obj/item/borg/chassis_mod/standard/drone
+
+/datum/design/item/robot_upgrade/chassis/eyebot
+	name = "Standard Chassis: Eyebot"
+	id = "borg_chassis_eyebot"
+	build_path = /obj/item/borg/chassis_mod/standard/eyebot
+
+//////////////
+// Service/Clerical
 
 /datum/design/item/robot_upgrade/chassis/waitress
 	name = "Service/Clerical Chassis: Waitress"
@@ -431,7 +453,6 @@
 	name = "Service/Clerical Chassis: Service Eyebot"
 	id = "borg_chassis_serviceye"
 	build_path = /obj/item/borg/chassis_mod/service/serviceeyebot
-
 
 ////////////
 // Mining Chassis
@@ -589,6 +610,12 @@
 	category = "Cyborg Modules"
 	materials = list(DEFAULT_WALL_MATERIAL = 25000, "phoron" = 10000, "gold" = 1000, "silver" = 1000)
 	desc = "A module that contains tools and equipment that the cyborg can use."
+
+/datum/design/item/robot_upgrade/module/standard
+	name = "Module Chip: Standard"
+	id = "borg_module_standard"
+	build_path = /obj/item/borg/module_chip/standard
+	materials = list(DEFAULT_WALL_MATERIAL = 25000, "glass" = 7500, "phoron" = 1500, "gold" = 2500, "silver" = 2500)
 
 /datum/design/item/robot_upgrade/module/surgeon
 	name = "Module Chip: Medical Surgeon"


### PR DESCRIPTION
<!-- 
!!IMPORTANT!!
Changes must be reviewed and approved by a developer before being merged.

If a developer has approved your PR, any other developer may immediately merge it, or the same developer may merge it after 24 hours.

A developer may not merge their own PR without the approval of two other developers.

Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Phoron costs for Mining borgs completely removed as to not cause instances where there isn't enough phoron for new miners, because there isn't enough miners to mine phoron. Phoron costs also removed for various service modules, and reduced for both Engineering and Medical modules. Module costs re-adjusted for various modules, mining module now requires uranium.

Chassis Modules now cost silver instead of phoron as to have people start using them to customize.

Security borg module should now spawn modules, security borgs already created will need their module re-installed.

Added in the Standard borg, along with accompanying chassis mods. The Standard cyborg now has a Inaprovline autoinjector for stabilizing persons in need, along with a metal synthesizer to make floor tiles.