### PR TITLE
Fixes all airlock electronics related stuff

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -20,14 +20,17 @@
 			if(employee)
 				var/pass = 1
 				var/one_pass = 0
-				for(var/x in req_access_business_list)
+				for(var/x in req_access_business_list)		//needs all
 					if(!(x in employee.accesses))
 						pass = 0
-				for(var/x in req_one_access_business_list)
-					if(!(x in employee.accesses))
-						one_pass = 1
-				if(!req_one_access_business_list.len) one_pass = 1
-				if(pass && one_pass)
+						break								//Break since we found one required access that we don't have on a list that we need ALL
+				if(req_one_access_business_list.len)
+					for(var/x in req_one_access_business_list)
+						if(x in employee.accesses)
+							one_pass = 1
+							break
+
+				if(pass && (one_pass || !req_one_access_business_list.len) )
 					return 1
 			return 0
 	if(req_access_personal)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1302,10 +1302,10 @@ About the new airlock wires panel:
 		secured_wires = electronics.secure
 		if(electronics.business_name)
 			if(electronics.one_access)
-				req_access_business_list = src.electronics.business_access
+				req_one_access_business_list = src.electronics.business_access	//for some reason we were inverting them
 
 			else
-				req_one_access_business_list = src.electronics.business_access
+				req_access_business_list = src.electronics.business_access
 			req_access_business = electronics.business_name
 
 		else

--- a/code/modules/modular_computers/file_system/programs/command/buisness.dm
+++ b/code/modules/modular_computers/file_system/programs/command/buisness.dm
@@ -119,7 +119,7 @@
 					data["employee_expenses"] = employee.expenses
 					data["employee_expense_limit"] = employee.expense_limit
 					var/list/formatted[0]
-					var/list/all_access = list("Sales", "Budget View", "Employee Control", "Upper Management", "Door Access 1", "Door Access 2", "Door Access 3")
+					var/list/all_access = ACCESS_BUSINESS_DEFAULT_ALL
 					for(var/x in all_access)
 						var/select = 0
 						if(x in employee.accesses)


### PR DESCRIPTION
Adds new access level for business to be used on the business airlock electronics.
Fixes probably everything with the airlock electronics, we can forget that this code even exists.

Added two new defines for ease-of-change's sake (was actually done like this cause i had custom access' in mind at the beginning)

Locked business electronics can only be unlocked by someone who has access (ACCESS_BUSINESS_ELETRONICS ) and belongs to the business that locked it.

Locking it with no access choosen will make it unlockable by someone else.

<!-- 
!!IMPORTANT!!
Changes must be reviewed and approved by a developer before being merged.

If a developer has approved your PR, any other developer may immediately merge it, or the same developer may merge it after 24 hours.

A developer may not merge their own PR without the approval of two other developers.

Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
