### PR TITLE
Fixes the box mixedglasses' UI, and probably other box's as well

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -342,21 +342,20 @@
 		max_storage_space = storage_slots*base_storage_cost(max_w_class)
 
 	prepare_ui()
-	spawn(100)
-		if(!map_storage_loaded)
-			if(startswith)
-				for(var/item_path in startswith)
-					var/list/data = startswith[item_path]
-					if(islist(data))
-						var/qty = data[1]
-						var/list/argsl = data.Copy()
-						argsl[1] = src
-						for(var/i in 1 to qty)
-							new item_path(arglist(argsl))
-					else
-						for(var/i in 1 to (isnull(data)? 1 : data))
-							new item_path(src)
-				update_icon()
+	if(!map_storage_loaded)
+		if(startswith)
+			for(var/item_path in startswith)
+				var/list/data = startswith[item_path]
+				if(islist(data))
+					var/qty = data[1]
+					var/list/argsl = data.Copy()
+					argsl[1] = src
+					for(var/i in 1 to qty)
+						new item_path(arglist(argsl))
+				else
+					for(var/i in 1 to (isnull(data)? 1 : data))
+						new item_path(src)
+			update_icon()
 
 /obj/item/weapon/storage/after_load()
 	. = ..()


### PR DESCRIPTION
Should fix some issues regarding boxes that have a preset 'startswith = list(...)' which would have its content's delayed upon spawning and therefore no max_w_class and max_storage_space (which is set right on Initialize, after spawn() but still before its statements run)

If this 10 seconds delay is REALLY NECCESSARY (i don't see how it is to be honest) then i'll work it around making an max_w_class and max_storage_space update followed by an UI update. Didn't go with that easier fix because a 10 seconds delay is plain dumb, it actually makes newly spawned boxes (or those straight from cargo) only have items on it after 10 seconds. There are few boxes that have different items on them, which is what "startswith" list does, different from other boxes which use only one item type on them so they aren't affected.

Tested almost every box there is. Could break other storage types ? I think not.

Fixed example: .../storage/box/mixedglasses

<!-- 
!!IMPORTANT!!
Changes must be reviewed and approved by a developer before being merged.

If a developer has approved your PR, any other developer may immediately merge it, or the same developer may merge it after 24 hours.

A developer may not merge their own PR without the approval of two other developers.

Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
