### PR TITLE
Fixes electric chair functionality AND duplication glitch

### DIFF
--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -99,7 +99,7 @@
 
 		M.Weaken(10)
 
-	if(master && wires & 1)
+	if(master) //before: if(master && wires & 1) not sure what to do here but clearing these fixed some of the issues
 		master.receive_signal()
 	return
 

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -43,6 +43,12 @@
 	overlays += image('icons/obj/objects.dmi', src, "echair_over", MOB_LAYER + 1, dir)	//there's probably a better way of handling this, but eh. -Pete
 	return
 
+/obj/structure/bed/chair/e_chair/update_icon()
+	..()
+	overlays.Cut()
+	overlays += image('icons/obj/objects.dmi', src, "echair_over", MOB_LAYER + 1, dir)	//there's probably a better way of handling this, but eh. -Pete
+	return
+
 /obj/structure/bed/chair/e_chair/proc/shock()
 	if(!on)
 		return

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -1,7 +1,9 @@
 /obj/structure/bed/chair/e_chair
 	name = "electric chair"
 	desc = "Looks absolutely SHOCKING!"
+	icon = 'icons/obj/objects.dmi'
 	icon_state = "echair0"
+	base_icon = "echair0"
 	var/on = 0
 	var/obj/item/assembly/shock_kit/part = null
 	var/last_time = 1.0
@@ -45,6 +47,9 @@
 
 /obj/structure/bed/chair/e_chair/update_icon()
 	..()
+	if(on)	icon_state = "echair0"
+	else	icon_state = "echair1"
+	icon_state = "echair0"
 	overlays.Cut()
 	overlays += image('icons/obj/objects.dmi', src, "echair_over", MOB_LAYER + 1, dir)	//there's probably a better way of handling this, but eh. -Pete
 	return

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -10,7 +10,7 @@
 
 /obj/structure/bed/chair/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
-	if(!padding_material && istype(W, /obj/item/assembly/shock_kit))
+	if(!padding_material && type == /obj/structure/bed/chair && istype(W, /obj/item/assembly/shock_kit))
 		var/obj/item/assembly/shock_kit/SK = W
 		if(!SK.status)
 			to_chat(user, "<span class='notice'>\The [SK] is not ready to be attached!</span>")


### PR DESCRIPTION
Had to re-create since the other one got stormed by merge commits and what not and im dumb

**ELECTRIC CHAIRS CAN ONLY BE MADE _STRICTLY_ ON A NORMAL STEEL CHAIR** (/obj/structure/bed/chair)