### PR TITLE
Slime nerfs

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -16,3 +16,4 @@
 	response_harm   = "stomps on"
 	mob_size = MOB_MINISCULE
 	possession_candidate = 1
+	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat

--- a/code/modules/surgery/slimes.dm
+++ b/code/modules/surgery/slimes.dm
@@ -100,7 +100,7 @@
 		var/coreType = target.GetCoreType()
 		new coreType(target.loc)
 	if(target.cores <= 0)
-		target.icon_state = "[target.colour] baby slime dead-nocore"
+		qdel(mob/living/carbon/slime/target)
 
 
 /datum/surgery_step/slime/saw_core/fail_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/slimes.dm
+++ b/code/modules/surgery/slimes.dm
@@ -101,6 +101,7 @@
 		new coreType(target.loc)
 	if(target.cores <= 0)
 		qdel(mob/living/carbon/slime/target)
+		visible_message("<span class='notice'>The [target] abruptly bubbles and burbles before dissolving away!</span>")
 
 
 /datum/surgery_step/slime/saw_core/fail_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)


### PR DESCRIPTION
Not really nerfs. When a slime runs out of cores, it should self-delete, and hopefully I'm not a moron and spawning runtimes again.

Similarly, lizards now have /meat/ added to their typing as a list of reagents, which should enable butchering.