### PR TITLE
Update girderlathe.dm

### DIFF
--- a/code/modules/construction/girderlathe.dm
+++ b/code/modules/construction/girderlathe.dm
@@ -45,8 +45,8 @@
 					stored_materials[M.material.type] += M.amount
 					qdel(M)
 		for(var/M in stored_materials)
-			if(!processing && stored_materials[M] >= 4)
-				stored_materials[M] -= 4
+			if(!processing && stored_materials[M] >= 2)
+				stored_materials[M] -= 2
 				processing = 1
 				sleep(80)
 				flick("lathe_o", src)

--- a/code/modules/construction/girders.dm
+++ b/code/modules/construction/girders.dm
@@ -202,9 +202,9 @@
 /obj/structure/girder/proc/dismantle(var/devastated)
 	playsound(get_turf(src), 'sound/items/Welder.ogg', 100, 1)
 	if(!devastated)
-		new material.stack_type(get_turf(src), 4)
+		new material.stack_type(get_turf(src), 2)
 		if(r_material)
-			new r_material.stack_type(get_turf(src), 6)
+			new r_material.stack_type(get_turf(src), 4)
 
 	material = null
 	r_material = null

--- a/code/modules/construction/girders.dm
+++ b/code/modules/construction/girders.dm
@@ -46,6 +46,11 @@
 				to_chat(user, "<span class='notice'>You dismantle \the [src].</span>")
 				dismantle()
 				return
+			if(Wrench(W, user, null, "You start to disassemble \the [src]"))
+				to_chat(user, "<span class='notice'>You disassemble \the [src] into parts.</span>")
+				new /obj/item/girderpart(get_turf(src), material)
+				qdel(src)
+				return
 			if(Crowbar(W, user))
 				to_chat(user, "<span class='notice'>You pry \the [src] [anchored ? "out of" : "into"] place</span>")
 				anchored = !anchored

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -32,7 +32,7 @@
 
 /material/steel/generate_recipes()
 	..()
-	recipes += new/datum/stack_recipe("wall girders", /obj/structure/girder, 4, time = 50, one_per_turf = 1, on_floor = 1)
+	recipes += new/datum/stack_recipe("wall girders", /obj/structure/girder, 6, time = 50, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("metal rod", /obj/item/stack/rods, 1, 2, 60)
 	recipes += new/datum/stack_recipe("regular floor tile", /obj/item/stack/tile/floor, 1, 4, 20)
 	recipes += new/datum/stack_recipe("machine frame", /obj/machinery/constructable_frame/machine_frame, 5, time = 25, one_per_turf = 1, on_floor = 1)


### PR DESCRIPTION
Buffs girderlathe by reducing mat cost for girders from 4 to 2 to give people a good reason to use it.
Girders already give back 2 materials when deconned, so it shouldn't break the game.

To clarify:
Hand building takes 4 to construct a girder
Then 4 to reinforced.
Deconstructing the wall gives 2
Deconstructing the girder gives 2.

Using a girderlathe uses 2 material sheets instead of 4, meaning a total cost of 6.
Rgirders and the like still have to be adjusted by hand, but it's still cheaper to girderlathe -> reinforced girder part after placing.