### PR TITLE
Fix cryonet to use last cryopod

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -221,12 +221,16 @@
 
 	if(character.spawn_type == 1)
 		var/datum/world_faction/faction = get_faction(character.spawn_loc)
-		var/spawnLocation = faction?.get_assignment(faction?.get_record(character.real_name)?.assignment_uid)?.cryo_net
-		if (character.spawn_loc_2)
-			// The character already has a spawn_loc_2 set by the cryopod they despawned in
+		var/assignmentSpawnLocation = faction?.get_assignment(faction?.get_record(character.real_name)?.assignment_uid)?.cryo_net
+		if (spawnLocation == "Last Known Cryonet")
+			// The character's assignment is set to spawn in their last cryo location
+			// Do nothing, leave it the way it is.
+		else if (spawnLocation)
+			// The character has a special cryo network set to override their normal spawn location
+			character.spawn_loc_2 = assignmentSpawnLocation
 		else
 			// The character doesn't have a spawn_loc_2, so use the one for their assignment or the default
-			character.spawn_loc_2 = spawnLocation ? spawnLocation : " default"
+			character.spawn_loc_2 = " default"
 
 		for(var/obj/machinery/cryopod/pod in GLOB.cryopods)
 			if(!pod.loc)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -222,10 +222,10 @@
 	if(character.spawn_type == 1)
 		var/datum/world_faction/faction = get_faction(character.spawn_loc)
 		var/assignmentSpawnLocation = faction?.get_assignment(faction?.get_record(character.real_name)?.assignment_uid)?.cryo_net
-		if (spawnLocation == "Last Known Cryonet")
+		if (assignmentSpawnLocation == "Last Known Cryonet")
 			// The character's assignment is set to spawn in their last cryo location
 			// Do nothing, leave it the way it is.
-		else if (spawnLocation)
+		else if (assignmentSpawnLocation)
 			// The character has a special cryo network set to override their normal spawn location
 			character.spawn_loc_2 = assignmentSpawnLocation
 		else

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -222,7 +222,11 @@
 	if(character.spawn_type == 1)
 		var/datum/world_faction/faction = get_faction(character.spawn_loc)
 		var/spawnLocation = faction?.get_assignment(faction?.get_record(character.real_name)?.assignment_uid)?.cryo_net
-		character.spawn_loc_2 = spawnLocation ? spawnLocation : " default"
+		if (character.spawn_loc_2)
+			// The character already has a spawn_loc_2 set by the cryopod they despawned in
+		else
+			// The character doesn't have a spawn_loc_2, so use the one for their assignment or the default
+			character.spawn_loc_2 = spawnLocation ? spawnLocation : " default"
 
 		for(var/obj/machinery/cryopod/pod in GLOB.cryopods)
 			if(!pod.loc)

--- a/code/modules/modular_computers/file_system/programs/command/faction_core.dm
+++ b/code/modules/modular_computers/file_system/programs/command/faction_core.dm
@@ -554,6 +554,7 @@
 					new_assignment.parent = selected_assignmentcategory
 					new_assignment.name = select_title
 					new_assignment.uid = select_name
+					new_assignment.cryo_net = "Last Known Cryonet"
 					selected_assignmentcategory.assignments |= new_assignment
 					to_chat(usr, "Assignment successfully created.")
 		if("create_assignment_two")
@@ -576,6 +577,7 @@
 					new_assignment.parent = selected_assignmentcategory2
 					new_assignment.name = select_title
 					new_assignment.uid = select_name
+					new_assignment.cryo_net = "Last Known Cryonet"
 					selected_assignmentcategory2.assignments |= new_assignment
 					to_chat(usr, "Assignment successfully created.")
 		if("edit_assignmentcategory")
@@ -781,6 +783,7 @@
 				connected_faction.cryo_networks -= choice
 		if("edit_assignment_cryonet")
 			var/list/choices = connected_faction.cryo_networks.Copy()
+			choices |= "Last Known Cryonet"
 			choices |= "default"
 			var/choice = input(usr,"Choose which cryo network the assignment should use.","Choose Cryo-net",null) as null|anything in choices
 			if(choice)


### PR DESCRIPTION
Prefer the following order for cryopod spawn:

1. Assignment cryonet for the cryo'd person's primary faction
2. Wherever the cryo'd person despawned last time
3. Default cryopods for the cryo'd person's primary faction