### PR TITLE
More ways to destroy cards

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -93,8 +93,21 @@ var/const/NO_EMAG_ACT = -50
 		qdel(src)
 
 	return 1
-	
-	
+
+/obj/item/weapon/card/attackby(var/obj/item/W, var/mob/user)
+	if(isWelder(W))
+		var/obj/item/weapon/weldingtool/WT = W
+		if(WT.remove_fuel(0,user))
+			for (var/mob/M in viewers(src))
+				M.show_message("<span class='notice'>[src] is melted by [user.name] with the welding tool.</span>", 3, "<span class='notice'>You hear welding.</span>", 2)
+			qdel(src)
+		return
+	if(isWirecutter(W))
+		for (var/mob/M in viewers(src))
+			M.show_message("<span class='notice'>[src] is sliced up by [user.name] with the wirecutters.</span>", 3, "<span class='notice'>You hear a snipping sound.</span>", 2)
+		qdel(src)
+		return
+
 /obj/item/weapon/card/expense // the fabled expense card
 	desc = "This card is used to expense invoices."
 	name = "expense card"

--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -6,14 +6,15 @@
 	density = 1
 	anchored = 1
 	flags = OBJ_ANCHORABLE|OBJ_CLIMBABLE
-	var/max_paper = 10
+	var/max_paper = 20
 	var/paperamount = 0
 	var/list/shred_amounts = list(
 		/obj/item/weapon/photo = 1,
 		/obj/item/weapon/shreddedp = 1,
 		/obj/item/weapon/paper = 1,
 		/obj/item/weapon/newspaper = 3,
-		/obj/item/weapon/card/id = 3,
+		/obj/item/weapon/card/id = 1,
+		/obj/item/weapon/card/expense = 1,
 		/obj/item/weapon/paper_bundle = 3,
 		)
 


### PR DESCRIPTION
- Expense cards can now be shredded
- ID and expense cards can now be melted
- ID and expense cards can now be cut up with wirecutters