### PR TITLE
Remotely revoke telepads

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/supply2.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/supply2.dm
@@ -35,8 +35,6 @@
 		connected_faction = program.computer.network_card.connected_network.holder
 	if(!connected_faction)
 		program.computer.kill_program()
-	if(!selected_telepads)
-		// That is fine, don't select all telepads by default
 	var/is_admin = (check_access(user, core_access_order_approval, connected_faction.uid) || check_access(user, core_access_invoicing, connected_faction.uid))
 	var/is_superadmin = (check_access(user, core_access_command_programs, connected_faction.uid))
 

--- a/nano/templates/supply.tmpl
+++ b/nano/templates/supply.tmpl
@@ -12,6 +12,7 @@
 	{{:helper.link('Recieve Imports', 'bullet', {'set_screen' : 3}, data.screen == 3 ? 'selected' : null)}}
 	{{:helper.link('View Export Orders', 'cart', {'set_screen' : 5}, data.screen == 5 ? 'selected' : null)}}
 	{{:helper.link('Send Exports', 'bullet', {'set_screen' : 6}, data.screen == 6 ? 'selected' : null)}}
+	{{:helper.link('Admin', 'bullet', {'set_screen' : 7}, data.screen == 7 ? 'selected' : null)}}
 </div>
 <hr>
 <span>Current Account: {{:data.faction_name}}<br>Current balance: {{:data.credits}} $$</span>
@@ -152,4 +153,30 @@
 			{{:helper.link('Initiate Telepads', 'check', {'launch_export' : 1})}}
 		</div>
 	</div>
+{{/if}}
+
+{{else data.screen == 7}}
+	{{if data.is_superadmin}}
+		<div class="item">
+			<div class="itemLabel">
+				Connected Telepads:
+			</div>
+			<div class="itemContent">
+				{{for data.telepads}}
+					{{:helper.link(value.name, '', {'toggle_telepad_revoke' : value.ref},null, value.selected ? 'selected' : null )}}
+				{{/for}}
+			</div>
+		</div>
+		<hr>
+		<div class="item">
+			<div class="itemLabel">
+				Actions Available:
+			</div>
+			<div class="itemContent">
+				{{:helper.link('Revoke Telepads', 'check', {'revoke_pad' : 1})}}
+			</div>
+		</div>	
+	{{else}}
+		<h3>Access denied: Missing identificaton or insufficient permissions.</h3>
+	{{/if}}
 {{/if}}


### PR DESCRIPTION
As a Supply Program user, if you have `core_access_command_programs` for the faction, you can use the Admin menu. The admin menu allows you to revoke the connection of rogue telepads.

Also fixes a bug where all possible import pads were selected if it didn't know which to use.