### PR TITLE
Attempt to reacquire channels of a headset after loading it

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -27,6 +27,9 @@
 			keyslot2 = new ks2type(src)
 	recalculateChannels(1)
 
+/obj/item/device/radio/headset/after_load()
+	recalculateChannels(1)
+
 /obj/item/device/radio/headset/Destroy()
 	qdel(keyslot1)
 	qdel(keyslot2)


### PR DESCRIPTION
This will probably fix the bug where headsets do not retain their channels across resets