### PR TITLE
Update organ.dm

### DIFF
--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -176,7 +176,7 @@ var/list/organ_cache = list()
 		return
 	if(dna)
 		if(!rejecting)
-			if(owner.blood_incompatible(dna.b_type, species))
+			if(owner.blood_incompatible(b_type, species))
 				rejecting = 1
 		else
 			rejecting++ //Rejection severity increases over time.
@@ -350,7 +350,7 @@ var/list/organ_cache = list()
 		if (INFECTION_LEVEL_THREE to INFINITY)
 			. +=  "Septic"
 	if(rejecting)
-		. += "Genetic Rejection"
+		. += "Organ Rejection"
 
 /obj/item/organ/proc/isrobotic()
 	return robotic >= ORGAN_ROBOT


### PR DESCRIPTION
Changes organs to only be rejected based on blood type and species, not DNA.

Part of bioprinter changes.

Ensures that organs can be transplanted, but still forces people to track bloodtype and stay organized.

However, I don't know how organ datums save, so it might set organs in a freezer to something odd.