### PR TITLE
Fix the crew monitor bug

### DIFF
--- a/nano/templates/crew_monitor_map_content.tmpl
+++ b/nano/templates/crew_monitor_map_content.tmpl
@@ -4,7 +4,7 @@ Used In File(s): \code\game\machinery\computer\crew.dm
  -->
 {{for data.crewmembers}}
     {{if value.sensor_type == 3 && value.z == config.mapZLevel}}
-        <div class="mapIcon mapIcon16 rank-{{:value.rank.ckey()}} {{:value.dead ? 'dead' : 'alive'}}" style="left: {{:(value.x + 0.2)}}px; bottom: {{:(value.y - 14.75)}}px;" unselectable="on">
+        <div class="mapIcon mapIcon16 {{:value.dead ? 'dead' : 'alive'}}" style="left: {{:(value.x + 0.2)}}px; bottom: {{:(value.y - 14.75)}}px;" unselectable="on">
             <div class="tooltip hidden">
 				{{:value.name}} ({{:value.assignment}}) - {{if data.stat == 0}} conscious {{else data.stat == 1}} unconscious {{else data.stat == 2}} deceased {{/if}} - pulse {{data.pulse}}bpm, body temperature {{data.bodytemp}}C</td> ({{:value.area}}: {{:value.x}}, {{:value.y}})
             </div>


### PR DESCRIPTION
This removes the `rank-` class from Crew Monitoring, which was causing a bug.

![image](https://user-images.githubusercontent.com/37093159/45904839-18e85b80-bda3-11e8-85b1-71c40b7a331c.png)
