### PR TITLE
Fix borgos in main

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -485,6 +485,10 @@ var/list/turret_icons
 	if(ishuman(L))	//if the target is a human, analyze threat level
 		if(assess_perp(L) < 4)
 			return TURRET_NOT_TARGET	//if threat level < 4, keep going
+			
+	if(issilicon(L)) // if the target is a silicon, analyze threat level
+		if(assess_borgo(L) < 4)
+			return TURRET_NOT_TARGET	//if threat level < 4, keep going
 
 	if(istype(L, /mob/living/bot)) //if the target is a bot, decide if it is ours
 		if(assess_bot(L))
@@ -517,6 +521,22 @@ var/list/turret_icons
 
 	return H.assess_perp(src, 0, 0, 1, 1, connected_faction) //if we're not checking faction or access, we're solely looking at wanted status, Arrest = pew pew
 
+/obj/machinery/porta_turret/proc/assess_borgo(var/mob/living/silicon/robot/R)
+	if(!R || !istype(R))
+		return 0
+ 	if(emagged)
+		return 10
+ 	if(connected_faction == null) //safety check
+		check_faction = 0
+		check_access = 0
+ 	if(check_faction && R.GetFaction() != connected_faction.uid)
+		return 10
+ 	if(check_access)
+		for(var/access in R.GetAccess(connected_faction.uid))
+			if(req_access["[access]"] > 0)
+				return R.assess_borgo(src, 0, 0, 1, 1, connected_faction)
+		return 10 //if they don't have any of the required access
+		
 /obj/machinery/porta_turret/proc/assess_bot(var/mob/living/bot/B)
 	if(!B || !istype(B))
 		return 1

--- a/html/changelogs/rhicora-pr-769.yml
+++ b/html/changelogs/rhicora-pr-769.yml
@@ -1,0 +1,33 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+ # Your name.
+author: rhicora
+ # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+ # Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Made turrets treat cyborgs with same threat criteria as humans"


### PR DESCRIPTION
Makes turrets not shoot borg friends unless they meet the same criteria as humans to get shot.

This duplicates https://github.com/Persistent-SS13/Persistent-Bay/pull/705, which was approved for main but got stepped on at some point during a revert.