### PR TITLE
Fixed Rotation Range (And Rotating While Incapacitated)

### DIFF
--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -327,6 +327,12 @@ Buildable meters
 	set name = "Rotate Pipe"
 	set src in view(1)
 
+	if(!usr || !Adjacent(usr))
+		return
+	
+	if(usr.incapacitated())
+		return
+
 	if ( usr.stat || usr.restrained() )
 		return
 

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -279,6 +279,13 @@ obj/structure/windoor_assembly/Destroy()
 	set category = "Object"
 	set src in oview(1)
 
+	if(!usr || !Adjacent(usr))
+		return
+	
+	if(usr.incapacitated())
+		return
+
+
 	if (src.anchored)
 		to_chat(usr, "It is fastened to the floor; therefore, you can't rotate it!")
 		return 0

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -274,8 +274,12 @@
 	set category = "Object"
 	set src in oview(1)
 
+	if(!usr || !Adjacent(usr))
+		return
+	
 	if(usr.incapacitated())
-		return 0
+		return
+
 
 	if(anchored)
 		to_chat(usr, "It is fastened to the floor therefore you can't rotate it!")

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -42,6 +42,9 @@
 	set category = "Object"
 	set src in oview(1)
 
+	if(!usr || !Adjacent(usr))
+		return
+	
 	if(usr.incapacitated())
 		return
 

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -96,6 +96,12 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	set category = "Object"
 	set src in oview(1)
 
+	if(!usr || !Adjacent(usr))
+		return
+	
+	if(usr.incapacitated())
+		return
+	
 	if (src.anchored || usr:stat)
 		to_chat(usr, "It is fastened to the floor!")
 		return 0

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -108,10 +108,16 @@
 		set category = "Object"
 		set name = "Rotate Pipe"
 		set src in view(1)
-
+		
+		if(!usr || !Adjacent(usr))
+			return
+	
+		if(usr.incapacitated())
+			return
+		
 		if(usr.stat)
 			return
-
+		
 		if(anchored)
 			to_chat(usr, "You must unfasten the pipe before rotating it.")
 			return


### PR DESCRIPTION
Changed objects changed in the alt-click addition, not sure if more are affected, added 


if(!usr || !Adjacent(usr))
	return

if(usr.incapacitated())
        return

to said files under the rotate() function, should terminate the function if the player acting on it is not beside, or is incapacitated.

#774
<!-- 
!!IMPORTANT!!
Changes must be reviewed and approved by a developer before being merged.

If a developer has approved your PR, any other developer may immediately merge it, or the same developer may merge it after 24 hours.

A developer may not merge their own PR without the approval of two other developers.

Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
