### PR TITLE
Properly identify borgos that don't have access

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -534,9 +534,12 @@ var/list/turret_icons
  	if(check_access)
 		for(var/access in R.GetAccess(connected_faction.uid))
 			if(req_access["[access]"] > 0)
-				return 0 // wtf? R.assess_borgo(src, 0, 0, 1, 1, connected_faction)
+				// Robots can call assess_perp too since they are mob/livings
+				return R.assess_perp(src, 0, 0, 1, 1, connected_faction)
 		return 10 //if they don't have any of the required access
-		
+
+	return R.assess_perp(src, 0, 0, 1, 1, connected_faction) //if we're not checking faction or access, we're solely looking at wanted status, Arrest = pew pew
+
 /obj/machinery/porta_turret/proc/assess_bot(var/mob/living/bot/B)
 	if(!B || !istype(B))
 		return 1


### PR DESCRIPTION
Currently, turrets will not shoot at any borgos if set to "check access". In this merge, check their access.