### PR TITLE
Allows mining borgs to traverse the asteroid

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -600,6 +600,7 @@ var/global/list/robot_modules = list(
 					"Drone" = "drone-miner",
 					"Doot" = "eyebot-miner"
 				)
+	no_slip = 1
 	supported_upgrades = list(/obj/item/borg/upgrade/jetpack)
 	module_type = "miner"
 	robo_icon_state = "robotMine"


### PR DESCRIPTION
Engineering borgs have this var that allows them to traverse tiles without gravity, this should function exactly like that.

<!-- 
!!IMPORTANT!!
Changes must be reviewed and approved by a developer before being merged.

If a developer has approved your PR, any other developer may immediately merge it, or the same developer may merge it after 24 hours.

A developer may not merge their own PR without the approval of two other developers.

Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
