### PR TITLE
Fix helmet + magboot duping on future spacesuits

### DIFF
--- a/code/datums/supplypacks/atmospherics.dm
+++ b/code/datums/supplypacks/atmospherics.dm
@@ -106,7 +106,9 @@
 //void suits
 /decl/hierarchy/supply_pack/atmospherics/voidsuit
 	name = "Voidsuits - Atmospherics Voidsuit"
-	contains = list(/obj/item/clothing/suit/space/void/atmos/prepared)
+	contains = list(/obj/item/clothing/head/helmet/space/void/atmos
+					/obj/item/clothing/suit/space/void/atmos
+					/obj/item/clothing/shoes/magboots)
 	cost = 100
 	containername = "\improper Atmospherics Voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
@@ -114,7 +116,9 @@
 
 /decl/hierarchy/supply_pack/atmospherics/voidsuit_heavyduty
 	name = "Voidsuits - Heavy-duty atmospherics voidsuit"
-	contains = list(/obj/item/clothing/suit/space/void/atmos/alt/prepared)
+	contains = list(/obj/item/clothing/head/helmet/space/void/atmos/alt
+					/obj/item/clothing/suit/space/void/atmos/alt
+					/obj/item/clothing/shoes/magboots)
 	cost = 150
 	containername = "\improper Heavy-duty atmospherics voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large

--- a/code/datums/supplypacks/atmospherics.dm
+++ b/code/datums/supplypacks/atmospherics.dm
@@ -106,8 +106,8 @@
 //void suits
 /decl/hierarchy/supply_pack/atmospherics/voidsuit
 	name = "Voidsuits - Atmospherics Voidsuit"
-	contains = list(/obj/item/clothing/head/helmet/space/void/atmos
-					/obj/item/clothing/suit/space/void/atmos
+	contains = list(/obj/item/clothing/head/helmet/space/void/atmos,
+					/obj/item/clothing/suit/space/void/atmos,
 					/obj/item/clothing/shoes/magboots)
 	cost = 100
 	containername = "\improper Atmospherics Voidsuit crate"
@@ -116,8 +116,8 @@
 
 /decl/hierarchy/supply_pack/atmospherics/voidsuit_heavyduty
 	name = "Voidsuits - Heavy-duty atmospherics voidsuit"
-	contains = list(/obj/item/clothing/head/helmet/space/void/atmos/alt
-					/obj/item/clothing/suit/space/void/atmos/alt
+	contains = list(/obj/item/clothing/head/helmet/space/void/atmos/alt,
+					/obj/item/clothing/suit/space/void/atmos/alt,
 					/obj/item/clothing/shoes/magboots)
 	cost = 150
 	containername = "\improper Heavy-duty atmospherics voidsuit crate"

--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -247,7 +247,9 @@
 
 /decl/hierarchy/supply_pack/engineering/voidsuit
 	name = "Engineering Voidsuit"
-	contains = list(/obj/item/clothing/suit/space/void/engineering/prepared)
+	contains = list(/obj/item/clothing/head/helmet/space/void/engineering
+					/obj/item/clothing/suit/space/void/engineering
+					/obj/item/clothing/shoes/magboots)
 	containername = "\improper Engineering Voidsuit"
 	containertype = /obj/structure/closet/crate/secure/large
 	cost = 100
@@ -255,7 +257,9 @@
 
 /decl/hierarchy/supply_pack/engineering/voidsuit_heavyduty
 	name = "Heavy Duty Engineering Voidsuit"
-	contains = list(/obj/item/clothing/suit/space/void/engineering/alt/prepared)
+	contains = list(/obj/item/clothing/head/helmet/space/void/engineering/alt
+					/obj/item/clothing/suit/space/void/engineering/alt
+					/obj/item/clothing/shoes/magboots)
 	containername = "\improper Heavy Duty Engineering Voidsuit"
 	containertype = /obj/structure/closet/crate/secure/large
 	cost = 180

--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -247,8 +247,8 @@
 
 /decl/hierarchy/supply_pack/engineering/voidsuit
 	name = "Engineering Voidsuit"
-	contains = list(/obj/item/clothing/head/helmet/space/void/engineering
-					/obj/item/clothing/suit/space/void/engineering
+	contains = list(/obj/item/clothing/head/helmet/space/void/engineering,
+					/obj/item/clothing/suit/space/void/engineering,
 					/obj/item/clothing/shoes/magboots)
 	containername = "\improper Engineering Voidsuit"
 	containertype = /obj/structure/closet/crate/secure/large
@@ -257,8 +257,8 @@
 
 /decl/hierarchy/supply_pack/engineering/voidsuit_heavyduty
 	name = "Heavy Duty Engineering Voidsuit"
-	contains = list(/obj/item/clothing/head/helmet/space/void/engineering/alt
-					/obj/item/clothing/suit/space/void/engineering/alt
+	contains = list(/obj/item/clothing/head/helmet/space/void/engineering/alt,
+					/obj/item/clothing/suit/space/void/engineering/alt,
 					/obj/item/clothing/shoes/magboots)
 	containername = "\improper Heavy Duty Engineering Voidsuit"
 	containertype = /obj/structure/closet/crate/secure/large

--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -205,7 +205,9 @@
 
 /decl/hierarchy/supply_pack/medical/voidsuit
 	name = "Medical Voidsuit"
-	contains = list(/obj/item/clothing/suit/space/void/medical/prepared)
+	contains = list(/obj/item/clothing/head/helmet/space/void/medical
+					/obj/item/clothing/suit/space/void/medical
+					/obj/item/clothing/shoes/magboots)
 	cost = 100
 	containername = "\improper Medical voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
@@ -213,7 +215,9 @@
 
 /decl/hierarchy/supply_pack/medical/voidsuit_heavyduty
 	name = "Heavy Duty Medical Voidsuit"
-	contains = list(/obj/item/clothing/suit/space/void/medical/alt/prepared)
+	contains = list(/obj/item/clothing/head/helmet/space/void/medical/alt
+					/obj/item/clothing/suit/space/void/medical/alt
+					/obj/item/clothing/shoes/magboots)
 	cost = 150
 	containername = "\improper Medical voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large

--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -205,8 +205,8 @@
 
 /decl/hierarchy/supply_pack/medical/voidsuit
 	name = "Medical Voidsuit"
-	contains = list(/obj/item/clothing/head/helmet/space/void/medical
-					/obj/item/clothing/suit/space/void/medical
+	contains = list(/obj/item/clothing/head/helmet/space/void/medical,
+					/obj/item/clothing/suit/space/void/medical,
 					/obj/item/clothing/shoes/magboots)
 	cost = 100
 	containername = "\improper Medical voidsuit crate"
@@ -215,8 +215,8 @@
 
 /decl/hierarchy/supply_pack/medical/voidsuit_heavyduty
 	name = "Heavy Duty Medical Voidsuit"
-	contains = list(/obj/item/clothing/head/helmet/space/void/medical/alt
-					/obj/item/clothing/suit/space/void/medical/alt
+	contains = list(/obj/item/clothing/head/helmet/space/void/medical/alt,
+					/obj/item/clothing/suit/space/void/medical/alt,
 					/obj/item/clothing/shoes/magboots)
 	cost = 150
 	containername = "\improper Medical voidsuit crate"

--- a/code/datums/supplypacks/operations.dm
+++ b/code/datums/supplypacks/operations.dm
@@ -130,7 +130,9 @@
 
 /decl/hierarchy/supply_pack/operations/minervoidsuit
 	name = "Cargo - Mining voidsuit"
-	contains = list(/obj/item/clothing/suit/space/void/mining/prepared)
+	contains = list(/obj/item/clothing/head/helmet/space/void/mining
+					/obj/item/clothing/suit/space/void/mining
+					/obj/item/clothing/shoes/magboots)
 	cost = 100
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper mining voidsuit"
@@ -138,7 +140,9 @@
 
 /decl/hierarchy/supply_pack/operations/minervoidsuit_heavyduty
 	name = "Cargo - Heavy-duty mining voidsuit"
-	contains = list(/obj/item/clothing/suit/space/void/mining/alt/prepared)
+	contains = list(/obj/item/clothing/head/helmet/space/void/mining/alt
+					/obj/item/clothing/suit/space/void/mining/alt
+					/obj/item/clothing/shoes/magboots)
 	cost = 200
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper Heavy-duty mining voidsuit"

--- a/code/datums/supplypacks/operations.dm
+++ b/code/datums/supplypacks/operations.dm
@@ -130,8 +130,8 @@
 
 /decl/hierarchy/supply_pack/operations/minervoidsuit
 	name = "Cargo - Mining voidsuit"
-	contains = list(/obj/item/clothing/head/helmet/space/void/mining
-					/obj/item/clothing/suit/space/void/mining
+	contains = list(/obj/item/clothing/head/helmet/space/void/mining,
+					/obj/item/clothing/suit/space/void/mining,
 					/obj/item/clothing/shoes/magboots)
 	cost = 100
 	containertype = /obj/structure/closet/crate/secure/large
@@ -140,8 +140,8 @@
 
 /decl/hierarchy/supply_pack/operations/minervoidsuit_heavyduty
 	name = "Cargo - Heavy-duty mining voidsuit"
-	contains = list(/obj/item/clothing/head/helmet/space/void/mining/alt
-					/obj/item/clothing/suit/space/void/mining/alt
+	contains = list(/obj/item/clothing/head/helmet/space/void/mining/alt,
+					/obj/item/clothing/suit/space/void/mining/alt,
 					/obj/item/clothing/shoes/magboots)
 	cost = 200
 	containertype = /obj/structure/closet/crate/secure/large

--- a/code/datums/supplypacks/science.dm
+++ b/code/datums/supplypacks/science.dm
@@ -38,8 +38,8 @@
 
 /decl/hierarchy/supply_pack/science/voidsuit
 	name = "Scientist Voidsuit"
-	contains = list(/obj/item/clothing/head/helmet/space/void/excavation
-					/obj/item/clothing/suit/space/void/excavation
+	contains = list(/obj/item/clothing/head/helmet/space/void/excavation,
+					/obj/item/clothing/suit/space/void/excavation,
 					/obj/item/clothing/shoes/magboots)
 	cost = 100
 	containertype = /obj/structure/closet/crate/secure/large

--- a/code/datums/supplypacks/science.dm
+++ b/code/datums/supplypacks/science.dm
@@ -38,7 +38,9 @@
 
 /decl/hierarchy/supply_pack/science/voidsuit
 	name = "Scientist Voidsuit"
-	contains = list(/obj/item/clothing/suit/space/void/excavation/prepared)
+	contains = list(/obj/item/clothing/head/helmet/space/void/excavation
+					/obj/item/clothing/suit/space/void/excavation
+					/obj/item/clothing/shoes/magboots)
 	cost = 100
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper Scientist Voidsuit"

--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -100,7 +100,9 @@
 
 /decl/hierarchy/supply_pack/security/voidsuit
 	name = "Voidsuit - Security voidsuit"
-	contains = list(/obj/item/clothing/suit/space/void/security/prepared)
+	contains = list(/obj/item/clothing/head/helmet/space/void/security
+					/obj/item/clothing/suit/space/void/security
+					/obj/item/clothing/shoes/magboots)
 	cost = 150
 	containername = "\improper Security voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
@@ -108,7 +110,9 @@
 
 /decl/hierarchy/supply_pack/security/voidsuit_heavyduty
 	name = "Voidsuit - Heavy-duty security voidsuit"
-	contains = list(/obj/item/clothing/suit/space/void/security/alt/prepared)
+	contains = list(/obj/item/clothing/head/helmet/space/void/security/alt
+					/obj/item/clothing/suit/space/void/security/alt
+					/obj/item/clothing/shoes/magboots)
 	cost = 250
 	containername = "\improper Heavy-duty security voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large

--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -100,8 +100,8 @@
 
 /decl/hierarchy/supply_pack/security/voidsuit
 	name = "Voidsuit - Security voidsuit"
-	contains = list(/obj/item/clothing/head/helmet/space/void/security
-					/obj/item/clothing/suit/space/void/security
+	contains = list(/obj/item/clothing/head/helmet/space/void/security,
+					/obj/item/clothing/suit/space/void/security,
 					/obj/item/clothing/shoes/magboots)
 	cost = 150
 	containername = "\improper Security voidsuit crate"
@@ -110,8 +110,8 @@
 
 /decl/hierarchy/supply_pack/security/voidsuit_heavyduty
 	name = "Voidsuit - Heavy-duty security voidsuit"
-	contains = list(/obj/item/clothing/head/helmet/space/void/security/alt
-					/obj/item/clothing/suit/space/void/security/alt
+	contains = list(/obj/item/clothing/head/helmet/space/void/security/alt,
+					/obj/item/clothing/suit/space/void/security/alt,
 					/obj/item/clothing/shoes/magboots)
 	cost = 250
 	containername = "\improper Heavy-duty security voidsuit crate"

--- a/code/datums/supplypacks/supply.dm
+++ b/code/datums/supplypacks/supply.dm
@@ -176,32 +176,32 @@
 /decl/hierarchy/supply_pack/supply/salvagedsuit
 	name = "Salvaged Voidsuit with Airtank"
 	contains = list(/obj/item/weapon/tank/oxygen,
-					/obj/item/clothing/head/helmet/space/void/engineering/salvage
-			 		/obj/item/clothing/suit/space/void/engineering/salvage
+					/obj/item/clothing/head/helmet/space/void/engineering/salvage,
+			 		/obj/item/clothing/suit/space/void/engineering/salvage,
 					 /obj/item/clothing/shoes/magboots)
 	cost = 50
 	containername = "\improper Salvaged Voidsuit crate"
 
 /decl/hierarchy/supply_pack/supply/voidsuit
 	name = "Basic Voidsuit"
-	contains = list(/obj/item/clothing/head/helmet/space/void
-					/obj/item/clothing/suit/space/void
+	contains = list(/obj/item/clothing/head/helmet/space/void,
+					/obj/item/clothing/suit/space/void,
 					/obj/item/clothing/shoes/magboots)
 	cost = 100
 	containername = "\improper Basic Voidsuit crate"
 
 /decl/hierarchy/supply_pack/supply/voidsuit_purple
 	name = "Deluxe Purple Voidsuit"
-	contains = list(/obj/item/clothing/head/helmet/space/void/exploration
-					/obj/item/clothing/suit/space/void/exploration
+	contains = list(/obj/item/clothing/head/helmet/space/void/exploration,
+					/obj/item/clothing/suit/space/void/exploration,
 					/obj/item/clothing/shoes/magboots)
 	cost = 300 //Expensive because moderately protects armor & heat
 	containername = "\improper Purple Voidsuit crate"
 
 /decl/hierarchy/supply_pack/supply/voidsuit_red
 	name = "Red Voidsuit"
-	contains = list(/obj/item/clothing/head/helmet/space/void/pilot
-					/obj/item/clothing/suit/space/void/pilot
+	contains = list(/obj/item/clothing/head/helmet/space/void/pilot,
+					/obj/item/clothing/suit/space/void/pilot,
 					/obj/item/clothing/shoes/magboots)
 	cost = 100
 	containername = "\improper Red Voidsuit crate"

--- a/code/datums/supplypacks/supply.dm
+++ b/code/datums/supplypacks/supply.dm
@@ -176,25 +176,33 @@
 /decl/hierarchy/supply_pack/supply/salvagedsuit
 	name = "Salvaged Voidsuit with Airtank"
 	contains = list(/obj/item/weapon/tank/oxygen,
-			 		/obj/item/clothing/suit/space/void/engineering/salvage/prepared)
+					/obj/item/clothing/head/helmet/space/void/engineering/salvage
+			 		/obj/item/clothing/suit/space/void/engineering/salvage
+					 /obj/item/clothing/shoes/magboots)
 	cost = 50
 	containername = "\improper Salvaged Voidsuit crate"
 
 /decl/hierarchy/supply_pack/supply/voidsuit
 	name = "Basic Voidsuit"
-	contains = list(/obj/item/clothing/suit/space/void/prepared)
+	contains = list(/obj/item/clothing/head/helmet/space/void
+					/obj/item/clothing/suit/space/void
+					/obj/item/clothing/shoes/magboots)
 	cost = 100
 	containername = "\improper Basic Voidsuit crate"
 
 /decl/hierarchy/supply_pack/supply/voidsuit_purple
 	name = "Deluxe Purple Voidsuit"
-	contains = list(/obj/item/clothing/suit/space/void/exploration/prepared)
+	contains = list(/obj/item/clothing/head/helmet/space/void/exploration
+					/obj/item/clothing/suit/space/void/exploration
+					/obj/item/clothing/shoes/magboots)
 	cost = 300 //Expensive because moderately protects armor & heat
 	containername = "\improper Purple Voidsuit crate"
 
 /decl/hierarchy/supply_pack/supply/voidsuit_red
 	name = "Red Voidsuit"
-	contains = list(/obj/item/clothing/suit/space/void/pilot/prepared)
+	contains = list(/obj/item/clothing/head/helmet/space/void/pilot
+					/obj/item/clothing/suit/space/void/pilot
+					/obj/item/clothing/shoes/magboots)
 	cost = 100
 	containername = "\improper Red Voidsuit crate"
 


### PR DESCRIPTION
Eyes mentioned that /prepared suits dupe their helmet on restarts and its not something that can be fixed with saving vars, so this changes all voidsuits orders to contain helmet+suit+magboots instead of /prepared suits