### PR TITLE
copper 10x crate.

### DIFF
--- a/code/datums/supplypacks/materials.dm
+++ b/code/datums/supplypacks/materials.dm
@@ -107,3 +107,8 @@
 	contains = list(/obj/item/stack/material/diamond/ten)
 	cost = 200
 	containername = "\improper Diamond sheets crate"
+/decl/hierarchy/supply_pack/materials/copper10
+	name = "Copper (x10)"
+	contains = list(/obj/item/stack/material/copper/ten)
+	cost = 80
+	containername = "\improper Copper bar crate"


### PR DESCRIPTION
Adds copper crate 10x at the price of silver. Copper is a commodity on the frontier as a valuable building resource and it is sold as such. Will keep the load off of buying the electrical maintenance crate /just/ for the wires it gives which also comes with the super load of clutter (power cells, gloves, flashlights, etc..)