### PR TITLE
Update code/modules/power/cell.dm

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -263,7 +263,7 @@
 	icon = 'icons/obj/power.dmi' //'icons/obj/harvest.dmi'
 	icon_state = "potato_cell" //"potato_battery"
 	maxcharge = 20
-	const/self_recharge = 0.1
+	const/self_recharge = 0.2
 
 /obj/item/weapon/cell/slime
 	name = "charged slime core"
@@ -272,5 +272,5 @@
 	icon = 'icons/mob/slimes.dmi' //'icons/obj/harvest.dmi'
 	icon_state = "yellow slime extract" //"potato_battery"
 	maxcharge = 200
-	const/self_recharge = 0.5
+	const/self_recharge = 1
 	matter = null

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -16,9 +16,6 @@
 	var/maxcharge = 1000 // Capacity in Wh
 	var/overlay_state
 	var/self_recharge = 0
-	var/charge_tick = 0
-	var/charge_tick_rate= 4
-	var/selfchargeamt = 0
 	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 50)
 
 
@@ -30,22 +27,19 @@
 
 /obj/item/weapon/cell/Initialize()
 	. = ..()
-	if(self_recharge)
+	if(self_recharge != 0)
 		START_PROCESSING(SSobj, src)
 	update_icon()
 
 /obj/item/weapon/cell/Destroy()
-	if(self_recharge)
+	if(self_recharge != 0)
 		STOP_PROCESSING(SSobj, src)
 	return ..()
 
 /obj/item/weapon/cell/Process()
-	if(self_recharge)
+	if(self_recharge != 0)
 		if(charge == maxcharge) return 0
-		charge_tick++
-		if(charge_tick < charge_tick_rate) return 0
-		charge_tick = 0
-		src.give(selfchargeamt)
+		src.give(self_recharge)
 		update_icon()
 
 /obj/item/weapon/cell/drain_power(var/drain_check, var/surge, var/power = 0)
@@ -269,10 +263,7 @@
 	icon = 'icons/obj/power.dmi' //'icons/obj/harvest.dmi'
 	icon_state = "potato_cell" //"potato_battery"
 	maxcharge = 20
-	charge_tick = 0
-	charge_tick_rate = 10
-	selfchargeamt = 1
-	self_recharge = 1
+	const/self_recharge = 0.1
 
 /obj/item/weapon/cell/slime
 	name = "charged slime core"
@@ -281,8 +272,5 @@
 	icon = 'icons/mob/slimes.dmi' //'icons/obj/harvest.dmi'
 	icon_state = "yellow slime extract" //"potato_battery"
 	maxcharge = 200
-	charge_tick = 0
-	charge_tick_rate = 10
-	selfchargeamt = 5
-	self_recharge = 1
+	const/self_recharge = 0.5
 	matter = null

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -276,7 +276,7 @@
 
 /obj/item/weapon/cell/slime
 	name = "charged slime core"
-	desc = "A yellow slime core infused with plasma, it crackles with power."
+	desc = "A yellow slime core infused with phoron, it crackles with power."
 	origin_tech = list(TECH_POWER = 2, TECH_BIO = 4)
 	icon = 'icons/mob/slimes.dmi' //'icons/obj/harvest.dmi'
 	icon_state = "yellow slime extract" //"potato_battery"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -31,11 +31,7 @@
 	update_icon()
 
 /obj/item/weapon/cell/Destroy()
-<<<<<<< HEAD
 	STOP_PROCESSING(SSobj, src)
-=======
-		STOP_PROCESSING(SSobj, src)
->>>>>>> efa672bc364263a824d88a150959bf71cabd7650
 	return ..()
 
 /obj/item/weapon/cell/Process()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -15,6 +15,10 @@
 	var/charge			                // Current charge
 	var/maxcharge = 1000 // Capacity in Wh
 	var/overlay_state
+	var/self_recharge = 0
+	var/charge_tick = 0
+	var/charge_tick_rate= 4
+	var/selfchargeamt = 0
 	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 50)
 
 
@@ -26,7 +30,23 @@
 
 /obj/item/weapon/cell/Initialize()
 	. = ..()
+	if(self_recharge)
+		START_PROCESSING(SSobj, src)
 	update_icon()
+
+/obj/item/weapon/cell/Destroy()
+	if(self_recharge)
+		STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/item/weapon/cell/Process()
+	if(self_recharge)
+		if(charge == maxcharge) return 0
+		charge_tick++
+		if(charge_tick < charge_tick_rate) return 0
+		charge_tick = 0
+		src.give(selfchargeamt)
+		update_icon()
 
 /obj/item/weapon/cell/drain_power(var/drain_check, var/surge, var/power = 0)
 
@@ -249,13 +269,20 @@
 	icon = 'icons/obj/power.dmi' //'icons/obj/harvest.dmi'
 	icon_state = "potato_cell" //"potato_battery"
 	maxcharge = 20
-
+	charge_tick = 0
+	charge_tick_rate = 10
+	selfchargeamt = 1
+	self_recharge = 1
 
 /obj/item/weapon/cell/slime
 	name = "charged slime core"
-	desc = "A yellow slime core infused with phoron, it crackles with power."
+	desc = "A yellow slime core infused with plasma, it crackles with power."
 	origin_tech = list(TECH_POWER = 2, TECH_BIO = 4)
 	icon = 'icons/mob/slimes.dmi' //'icons/obj/harvest.dmi'
 	icon_state = "yellow slime extract" //"potato_battery"
 	maxcharge = 200
+	charge_tick = 0
+	charge_tick_rate = 10
+	selfchargeamt = 5
+	self_recharge = 1
 	matter = null

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -27,20 +27,18 @@
 
 /obj/item/weapon/cell/Initialize()
 	. = ..()
-	if(self_recharge != 0)
-		START_PROCESSING(SSobj, src)
+	START_PROCESSING(SSobj, src)
 	update_icon()
 
 /obj/item/weapon/cell/Destroy()
-	if(self_recharge != 0)
-		STOP_PROCESSING(SSobj, src)
+	STOP_PROCESSING(SSobj, src)
 	return ..()
 
 /obj/item/weapon/cell/Process()
-	if(self_recharge != 0)
-		if(charge == maxcharge) return 0
-		src.give(self_recharge)
-		update_icon()
+    var/power = Clamp(charge + self_recharge, 0, maxcharge)
+    if(charge != power)
+        update_icon()
+    charge = power
 
 /obj/item/weapon/cell/drain_power(var/drain_check, var/surge, var/power = 0)
 
@@ -263,7 +261,7 @@
 	icon = 'icons/obj/power.dmi' //'icons/obj/harvest.dmi'
 	icon_state = "potato_cell" //"potato_battery"
 	maxcharge = 20
-	const/self_recharge = 0.2
+	self_recharge = 0.2
 
 /obj/item/weapon/cell/slime
 	name = "charged slime core"
@@ -272,5 +270,5 @@
 	icon = 'icons/mob/slimes.dmi' //'icons/obj/harvest.dmi'
 	icon_state = "yellow slime extract" //"potato_battery"
 	maxcharge = 200
-	const/self_recharge = 1
+	self_recharge = 1
 	matter = null


### PR DESCRIPTION
Makes potato cells and slime cores self-charging once again. Things have been tested and a cat doing zero division has been removed.

The charge is an extremely low trickle-charge, and the max capacity of these cells is insignificant compared to many others.