### PR TITLE
Update code/modules/power/cell.dm

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -15,6 +15,7 @@
 	var/charge			                // Current charge
 	var/maxcharge = 1000 // Capacity in Wh
 	var/overlay_state
+	var/self_recharge = 0
 	matter = list(DEFAULT_WALL_MATERIAL = 700, "glass" = 50)
 
 
@@ -26,7 +27,18 @@
 
 /obj/item/weapon/cell/Initialize()
 	. = ..()
+	START_PROCESSING(SSobj, src)
 	update_icon()
+
+/obj/item/weapon/cell/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/item/weapon/cell/Process()
+    var/power = Clamp(charge + self_recharge, 0, maxcharge)
+    if(charge != power)
+        update_icon()
+    charge = power
 
 /obj/item/weapon/cell/drain_power(var/drain_check, var/surge, var/power = 0)
 
@@ -249,7 +261,7 @@
 	icon = 'icons/obj/power.dmi' //'icons/obj/harvest.dmi'
 	icon_state = "potato_cell" //"potato_battery"
 	maxcharge = 20
-
+	self_recharge = 0.2
 
 /obj/item/weapon/cell/slime
 	name = "charged slime core"
@@ -258,4 +270,5 @@
 	icon = 'icons/mob/slimes.dmi' //'icons/obj/harvest.dmi'
 	icon_state = "yellow slime extract" //"potato_battery"
 	maxcharge = 200
+	self_recharge = 1
 	matter = null


### PR DESCRIPTION
Makes potato cells and slime cores recharge themselves very slowly; both have a lower power maximum power capacity of other cell types, and the self-charging is very minor.

This is also a buff to defibs and other types of admin-spawn items that use the potato cell in them but also have self-recharging built into the item itself.

Remade the branch due to the last one being ugly from repeated editing and in the interest of keeping things neat.