### PR TITLE
Uncomments some viruses that were commented out.

### DIFF
--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -78,7 +78,6 @@
 				if(O)
 					O.droplimb(0,DROPLIMB_BLUNT)
 
-/**
 /datum/disease2/effect/radian
 	name = "Radian's Syndrome"
 	stage = 4
@@ -86,7 +85,7 @@
 	badness = VIRUS_COMMON
 	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.apply_effect(2*multiplier, IRRADIATE, blocked = 0)
-**/
+
 /datum/disease2/effect/deaf
 	name = "Dead Ear Syndrome"
 	stage = 4
@@ -100,14 +99,14 @@
 	badness = VIRUS_EXOTIC
 	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.monkeyize()
-/**
+
 /datum/disease2/effect/killertoxins
 	name = "Toxification Syndrome"
 	stage = 4
 	badness = VIRUS_COMMON
 	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.adjustToxLoss(15*multiplier)
-**/
+
 /datum/disease2/effect/dna
 	name = "Reverse Pattern Syndrome"
 	stage = 4
@@ -176,7 +175,7 @@
 			E.min_broken_damage = initial(E.min_broken_damage)
 
 ////////////////////////STAGE 3/////////////////////////////////
-/**
+
 /datum/disease2/effect/toxins
 	name = "Hyperacidity"
 	stage = 3
@@ -184,7 +183,7 @@
 	badness = VIRUS_COMMON
 	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.adjustToxLoss((2*multiplier))
-**/
+
 /datum/disease2/effect/shakey
 	name = "World Shaking Syndrome"
 	stage = 3
@@ -199,7 +198,7 @@
 		mob.dna.SetSEState(GLOB.REMOTETALKBLOCK,1)
 		domutcheck(mob, null, MUTCHK_FORCED)
 **/
-/**
+
 /datum/disease2/effect/mind
 	name = "Lazy Mind Syndrome"
 	stage = 3
@@ -208,7 +207,7 @@
 		var/obj/item/organ/internal/brain/B = mob.internal_organs_by_name[BP_BRAIN]
 		if (B && B.damage < B.min_broken_damage)
 			B.take_damage(5)
-**/
+
 /datum/disease2/effect/deaf
 	name = "Hard of Hearing Syndrome"
 	stage = 3
@@ -221,14 +220,14 @@
 	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		to_chat(mob, "<span class='notice'>You have trouble telling right and left apart all of a sudden.</span>")
 		mob.confused += 10
-/**
+
 /datum/disease2/effect/mutation
 	name = "DNA Degradation"
 	stage = 3
 	badness = VIRUS_COMMON
 	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.apply_damage(2, CLONE)
-**/
+
 /datum/disease2/effect/chem_synthesis
 	name = "Chemical Synthesis"
 	stage = 3
@@ -257,13 +256,13 @@
 	allow_multiple = 1
 
 ////////////////////////STAGE 2/////////////////////////////////
-/**
+
 /datum/disease2/effect/drowsness
 	name = "Automated Sleeping Syndrome"
 	stage = 2
 	activate(var/mob/living/carbon/human/mob,var/multiplier)
 		mob.drowsyness += 10
-**/
+
 /datum/disease2/effect/sleepy
 	name = "Resting Syndrome"
 	stage = 2


### PR DESCRIPTION
:cl: Pandolphina
tweak: Uncomments a few Stage 4/Stage 3 viruses
/:cl:

Okey, reasoning time. First off, Stage 4's can't be obtained without admemes anyway so no reason to comment them out.

Second, the big evil bad random virus was removed.

Also All-Vax prevents "entire station dies from a cough that mutated the poison trait".

Look some people just want to be executed under the Space Geneva convention for making bioweapons. May be used as an NT sabotage as well.