### PR TITLE
Adds the Ammunition Fabricator.

### DIFF
--- a/code/game/machinery/ammofab.dm
+++ b/code/game/machinery/ammofab.dm
@@ -1,0 +1,8 @@
+/obj/machinery/autolathe/ammo_fab
+	name = "ammunition fabricator"
+	desc = "Fabricates many types of ammunition, magazines and boxes."
+	icon_state = "autolathe"
+
+
+	machine_recipes = newlist(/datum/autolathe/recipe/shotgun_blanks,/datum/autolathe/recipe/shotgun_beanbag,/datum/autolathe/recipe/shotgun_rubber,/datum/autolathe/recipe/shotgun_flash,/datum/autolathe/recipe/magazine_rubber,/datum/autolathe/recipe/speedloader_44_rubber,/datum/autolathe/recipe/magazine_flash,/datum/autolathe/recipe/magazine_smg_rubber,/datum/autolathe/recipe/magazine_revolver_1, /datum/autolathe/recipe/magazine_revolver_2,/datum/autolathe/recipe/speedloader_44,/datum/autolathe/recipe/magazine_revolver_3, /datum/autolathe/recipe/magazine_revolver_4, /datum/autolathe/recipe/magazine_stetchkin,/datum/autolathe/recipe/magazine_stetchkin_flash, /datum/autolathe/recipe/magazine_c20r,/datum/autolathe/recipe/magazine_arifle,/datum/autolathe/recipe/magazine_smg,/datum/autolathe/recipe/magazine_carbine,/datum/autolathe/recipe/shotgun,/datum/autolathe/recipe/shotgun_pellet)
+

--- a/code/game/machinery/ammofab_datums.dm
+++ b/code/game/machinery/ammofab_datums.dm
@@ -1,0 +1,105 @@
+
+/datum/autolathe/recipe/shotgun_blanks
+	name = "ammunition (shotgun, blank)"
+	path = /obj/item/ammo_casing/shotgun/blank
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/shotgun_beanbag
+	name = "ammunition (shotgun, beanbag)"
+	path = /obj/item/ammo_casing/shotgun/beanbag
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/shotgun_rubber
+	name = "ammunition (shotgun, rubber)"
+	path = /obj/item/ammo_casing/shotgun/rubber
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/shotgun_flash
+	name = "ammunition (shotgun, flash)"
+	path = /obj/item/ammo_casing/shotgun/flash
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_rubber
+	name = "ammunition (.45, rubber)"
+	path = /obj/item/ammo_magazine/c45m/rubber
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/speedloader_44_rubber
+	name = "speed loader (.44 magnum, rubber)"
+	path = /obj/item/ammo_magazine/c44/rubber
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_flash
+	name = "ammunition (.45, flash)"
+	path = /obj/item/ammo_magazine/c45m/flash
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_smg_rubber
+	name = "ammunition (9mm rubber top mounted)"
+	path = /obj/item/ammo_magazine/mc9mmt/rubber
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_revolver_1
+	name = "ammunition (.357)"
+	path = /obj/item/ammo_magazine/a357
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_revolver_2
+	name = "ammunition (.45)"
+	path = /obj/item/ammo_magazine/c45m
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/speedloader_44
+	name = "speed loader (.44 magnum)"
+	path = /obj/item/ammo_magazine/c44
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_revolver_3
+	name = "ammunition (.38)"
+	path = /obj/item/ammo_magazine/c38
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_revolver_4
+	name = "ammunition (.50AE)"
+	path = /obj/item/ammo_magazine/c50
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_stetchkin
+	name = "ammunition (9mm)"
+	path = /obj/item/ammo_magazine/mc9mm
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_stetchkin_flash
+	name = "ammunition (9mm, flash)"
+	path = /obj/item/ammo_magazine/mc9mm/flash
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_c20r
+	name = "ammunition (10mm)"
+	path = /obj/item/ammo_magazine/a10mm
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_arifle
+	name = "ammunition (5.56mm)"
+	path = /obj/item/ammo_magazine/c556
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_smg
+	name = "ammunition (9mm top mounted)"
+	path = /obj/item/ammo_magazine/mc9mmt
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_carbine
+	name = "ammunition (7.62mm)"
+	path = /obj/item/ammo_magazine/a762
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/shotgun
+	name = "ammunition (slug, shotgun)"
+	path = /obj/item/ammo_casing/shotgun
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/shotgun_pellet
+	name = "ammunition (shell, shotgun)"
+	path = /obj/item/ammo_casing/shotgun/pellet
+	category = "Arms and Ammunition"

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -324,53 +324,6 @@ var/const/EXTRA_COST_FACTOR = 1
 	path = /obj/item/weapon/syringe_cartridge
 	category = "Arms and Ammunition"
 
-/datum/autolathe/recipe/shotgun_blanks
-	name = "ammunition (shotgun, blank)"
-	path = /obj/item/ammo_casing/shotgun/blank
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/shotgun_beanbag
-	name = "ammunition (shotgun, beanbag)"
-	path = /obj/item/ammo_casing/shotgun/beanbag
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/shotgun_rubber
-	name = "ammunition (shotgun, rubber)"
-	path = /obj/item/ammo_casing/shotgun/rubber
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/shotgun_flash
-	name = "ammunition (shotgun, flash)"
-	path = /obj/item/ammo_casing/shotgun/flash
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/magazine_rubber
-	name = "ammunition (.45, rubber)"
-	path = /obj/item/ammo_magazine/c45m/rubber
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/speedloader_44_rubber
-	name = "speed loader (.44 magnum, rubber)"
-	path = /obj/item/ammo_magazine/c44/rubber
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/magazine_flash
-	name = "ammunition (.45, flash)"
-	path = /obj/item/ammo_magazine/c45m/flash
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/magazine_smg_rubber
-	name = "ammunition (9mm rubber top mounted)"
-	path = /obj/item/ammo_magazine/mc9mmt/rubber
-	hidden = 1
-	category = "Arms and Ammunition"
-
 /datum/autolathe/recipe/consolescreen
 	name = "console screen"
 	path = /obj/item/weapon/stock_parts/console_screen
@@ -473,105 +426,10 @@ var/const/EXTRA_COST_FACTOR = 1
 	hidden = 1
 	category = "Arms and Ammunition"
 
-/datum/autolathe/recipe/magazine_revolver_1
-	name = "ammunition (.357)"
-	path = /obj/item/ammo_magazine/a357
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/magazine_revolver_2
-	name = "ammunition (.45)"
-	path = /obj/item/ammo_magazine/c45m
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/speedloader_44
-	name = "speed loader (.44 magnum)"
-	path = /obj/item/ammo_magazine/c44
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/magazine_revolver_3
-	name = "ammunition (.38)"
-	path = /obj/item/ammo_magazine/c38
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/magazine_revolver_4
-	name = "ammunition (.50AE)"
-	path = /obj/item/ammo_magazine/c50
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/magazine_stetchkin
-	name = "ammunition (9mm)"
-	path = /obj/item/ammo_magazine/mc9mm
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/magazine_stetchkin_flash
-	name = "ammunition (9mm, flash)"
-	path = /obj/item/ammo_magazine/mc9mm/flash
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/magazine_c20r
-	name = "ammunition (10mm)"
-	path = /obj/item/ammo_magazine/a10mm
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/magazine_arifle
-	name = "ammunition (5.56mm)"
-	path = /obj/item/ammo_magazine/c556
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/magazine_smg
-	name = "ammunition (9mm top mounted)"
-	path = /obj/item/ammo_magazine/mc9mmt
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/magazine_carbine
-	name = "ammunition (7.62mm)"
-	path = /obj/item/ammo_magazine/a762
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/shotgun
-	name = "ammunition (slug, shotgun)"
-	path = /obj/item/ammo_casing/shotgun
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/shotgun_pellet
-	name = "ammunition (shell, shotgun)"
-	path = /obj/item/ammo_casing/shotgun/pellet
-	hidden = 1
-	category = "Arms and Ammunition"
 
 /datum/autolathe/recipe/tacknife
 	name = "tactical knife"
 	path = /obj/item/weapon/material/hatchet/tacknife
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/stunshell
-	name = "ammunition (stun cartridge, shotgun)"
-	path = /obj/item/ammo_casing/shotgun/stunshell
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/magazine_uzi
-	name = "ammunition (machine.45)"
-	path = /obj/item/ammo_magazine/c45uzi
-	hidden = 1
-	category = "Arms and Ammunition"
-
-/datum/autolathe/recipe/magazine_deagle
-	name = "ammunition (.50 AE)"
-	path = /obj/item/ammo_magazine/a50
 	hidden = 1
 	category = "Arms and Ammunition"
 

--- a/code/game/objects/items/weapons/circuitboards/machinery/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/research.dm
@@ -31,6 +31,9 @@ obj/item/weapon/circuitboard/rdserver
 							/obj/item/weapon/stock_parts/manipulator = 1,
 							/obj/item/weapon/stock_parts/console_screen = 1)
 
+	var/list/names_paths = list(/obj/machinery/autolathe/ = "Autolathe",
+							/obj/machinery/autolathe/ammo_fab = "Ammunition Fabricator",)
+
 /obj/item/weapon/circuitboard/protolathe
 	name = T_BOARD("protolathe")
 	build_path = /obj/machinery/r_n_d/protolathe

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -7,7 +7,7 @@
 	icon_state = "38"
 	caliber = "357"
 	ammo_type = /obj/item/ammo_casing/a357
-	matter = list(DEFAULT_WALL_MATERIAL = 1260)
+	matter = list(DEFAULT_WALL_MATERIAL = 1260, /datum/reagent/aluminum = 30)//Speadloaders are less efficient, and should be balanced
 	max_ammo = 6
 	multiple_sprites = 1
 
@@ -17,7 +17,7 @@
 	icon_state = "38"
 	caliber = ".50"
 	ammo_type = /obj/item/ammo_casing/a50
-	matter = list(DEFAULT_WALL_MATERIAL = 1260)
+	matter = list(DEFAULT_WALL_MATERIAL = 1260, /datum/reagent/aluminum = 40)//The fucking instant kill device costs more
 	max_ammo = 6
 	multiple_sprites = 1
 
@@ -26,7 +26,7 @@
 	desc = "A speed loader for revolvers."
 	icon_state = "38"
 	caliber = "38"
-	matter = list(DEFAULT_WALL_MATERIAL = 360)
+	matter = list(DEFAULT_WALL_MATERIAL = 360, /datum/reagent/aluminum = 20)
 	ammo_type = /obj/item/ammo_casing/c38
 	max_ammo = 6
 	multiple_sprites = 1
@@ -34,6 +34,7 @@
 /obj/item/ammo_magazine/c38/rubber
 	name = "speed loader (.38, rubber)"
 	icon_state = "R38"
+	matter =list("plastic" = 1260, /datum/reagent/aluminum = 10)
 	ammo_type = /obj/item/ammo_casing/c38/rubber
 
 /obj/item/ammo_magazine/c44
@@ -41,7 +42,7 @@
 	desc = "A speed loader for revolvers."
 	icon_state = "38"
 	ammo_type = /obj/item/ammo_casing/c44
-	matter = list(DEFAULT_WALL_MATERIAL = 450)
+	matter = list(DEFAULT_WALL_MATERIAL = 450, /datum/reagent/aluminum = 20)
 	caliber = ".44"
 	max_ammo = 6
 	multiple_sprites = 1
@@ -49,6 +50,7 @@
 /obj/item/ammo_magazine/c44/rubber
 	name = "speed loader (.44 magnum, rubber)"
 	icon_state = "R38"
+	matter = list("plastic" = 1300, /datum/reagent/aluminum = 10)
 	ammo_type = /obj/item/ammo_casing/c44/rubber
 
 /obj/item/ammo_magazine/c45m
@@ -56,7 +58,7 @@
 	icon_state = "45"
 	mag_type = MAGAZINE
 	ammo_type = /obj/item/ammo_casing/c45
-	matter = list(DEFAULT_WALL_MATERIAL = 525) //metal costs are very roughly based around 1 .45 casing = 75 metal
+	matter = list(DEFAULT_WALL_MATERIAL = 525, /datum/reagent/aluminum = 20) //metal costs are very roughly based around 1 .45 casing = 75 metal
 	caliber = ".45"
 	max_ammo = 7
 	multiple_sprites = 1
@@ -66,6 +68,7 @@
 
 /obj/item/ammo_magazine/c45m/rubber
 	name = "magazine (.45, rubber)"
+	matter = list("plastic" = 1200, /datum/reagent/aluminum = 10)
 	ammo_type = /obj/item/ammo_casing/c45/rubber
 
 /obj/item/ammo_magazine/c45m/practice
@@ -74,6 +77,7 @@
 
 /obj/item/ammo_magazine/c45m/flash
 	name = "magazine (.45, flash)"
+	matter = list(DEFAULT_WALL_MATERIAL = 525, /datum/reagent/aluminum = 20, /datum/reagent/sulfur = 10)
 	ammo_type = /obj/item/ammo_casing/c45/flash
 
 /obj/item/ammo_magazine/c45uzi
@@ -81,7 +85,7 @@
 	icon_state = "uzi45"
 	mag_type = MAGAZINE
 	ammo_type = /obj/item/ammo_casing/c45
-	matter = list(DEFAULT_WALL_MATERIAL = 1200)
+	matter = list(DEFAULT_WALL_MATERIAL = 1200, /datum/reagent/aluminum = 20)
 	caliber = ".45"
 	max_ammo = 16
 	multiple_sprites = 1
@@ -94,7 +98,7 @@
 	icon_state = "9x19p"
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
-	matter = list(DEFAULT_WALL_MATERIAL = 600)
+	matter = list(DEFAULT_WALL_MATERIAL = 600,/datum/reagent/aluminum = 20)
 	caliber = "9mm"
 	ammo_type = /obj/item/ammo_casing/c9mm
 	max_ammo = 10
@@ -105,13 +109,14 @@
 
 /obj/item/ammo_magazine/mc9mm/flash
 	name = "magazine (9mm, flash)"
+	matter = list(DEFAULT_WALL_MATERIAL = 600,/datum/reagent/aluminum = 20, /datum/reagent/sulfur = 10)
 	ammo_type = /obj/item/ammo_casing/c9mm/flash
 
 /obj/item/ammo_magazine/box/c9mm
 	name = "ammunition box (9mm)"
 	icon_state = "9mm"
 	origin_tech = list(TECH_COMBAT = 2)
-	matter = list(DEFAULT_WALL_MATERIAL = 1800)
+	matter = list(DEFAULT_WALL_MATERIAL = 1800, /datum/reagent/aluminum = 40)
 	caliber = "9mm"
 	ammo_type = /obj/item/ammo_casing/c9mm
 	max_ammo = 30
@@ -142,7 +147,7 @@
 	icon_state = "9mmt"
 	mag_type = MAGAZINE
 	ammo_type = /obj/item/ammo_casing/c9mm
-	matter = list(DEFAULT_WALL_MATERIAL = 1200)
+	matter = list(DEFAULT_WALL_MATERIAL = 1200, /datum/reagent/aluminum = 20)
 	caliber = "9mm"
 	max_ammo = 20
 	multiple_sprites = 1
@@ -152,6 +157,7 @@
 
 /obj/item/ammo_magazine/mc9mmt/rubber
 	name = "top mounted magazine (9mm, rubber)"
+	matter = list("plastic" = 1000, /datum/reagent/aluminum = 10)
 	ammo_type = /obj/item/ammo_casing/c9mm/rubber
 
 /obj/item/ammo_magazine/mc9mmt/practice
@@ -163,7 +169,7 @@
 	icon_state = "9mm"
 	origin_tech = list(TECH_COMBAT = 2)
 	caliber = ".45"
-	matter = list(DEFAULT_WALL_MATERIAL = 2250)
+	matter = list(DEFAULT_WALL_MATERIAL = 2250, /datum/reagent/aluminum = 40)
 	ammo_type = /obj/item/ammo_casing/c45
 	max_ammo = 30
 
@@ -176,7 +182,7 @@
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
 	caliber = "10mm"
-	matter = list(DEFAULT_WALL_MATERIAL = 1500)
+	matter = list(DEFAULT_WALL_MATERIAL = 1500, /datum/reagent/aluminum = 20)
 	ammo_type = /obj/item/ammo_casing/a10mm
 	max_ammo = 20
 	multiple_sprites = 1
@@ -190,7 +196,7 @@
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
 	caliber = "a762"
-	matter = list(DEFAULT_WALL_MATERIAL = 1800)
+	matter = list(DEFAULT_WALL_MATERIAL = 1800, /datum/reagent/aluminum = 25)
 	ammo_type = /obj/item/ammo_casing/a762
 	max_ammo = 15 //if we lived in a world where normal mags had 30 rounds, this would be a 20 round mag
 	multiple_sprites = 1
@@ -208,7 +214,7 @@
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
 	caliber = ".50"
-	matter = list(DEFAULT_WALL_MATERIAL = 1260)
+	matter = list(DEFAULT_WALL_MATERIAL = 1260, /datum/reagent/aluminum = 35)//Slightly less than the death revolver, but still expensive.
 	ammo_type = /obj/item/ammo_casing/a50
 	max_ammo = 7
 	multiple_sprites = 1
@@ -234,7 +240,7 @@
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
 	caliber = "a556"
-	matter = list(DEFAULT_WALL_MATERIAL = 4500)
+	matter = list(DEFAULT_WALL_MATERIAL = 4500, /datum/reagent/aluminum = 50)
 	ammo_type = /obj/item/ammo_casing/a556
 	max_ammo = 50
 	multiple_sprites = 1
@@ -247,7 +253,7 @@
 	icon_state = "c762"
 	mag_type = MAGAZINE
 	caliber = "a556"
-	matter = list(DEFAULT_WALL_MATERIAL = 1800)
+	matter = list(DEFAULT_WALL_MATERIAL = 1800, /datum/reagent/aluminum = 35)
 	ammo_type = /obj/item/ammo_casing/a556
 	max_ammo = 20
 	multiple_sprites = 1
@@ -259,6 +265,6 @@
 	caliber = "caps"
 	color = "#ff0000"
 	ammo_type = /obj/item/ammo_casing/cap
-	matter = list(DEFAULT_WALL_MATERIAL = 600)
+	matter = list("plastic" = 400)
 	max_ammo = 7
 	multiple_sprites = 1

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -789,7 +789,7 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/device/mmi/radio_enabled
 	category = "Misc"
 	sort_string = "VACBB"
-	
+
 /datum/design/item/defib
 	name = "auto-resuscitator"
 	id = "defibrillator"


### PR DESCRIPTION
:cl: Pandolphina
add: Adds the Ammunition Fabricator. Obtained by screwdrivering an autolathe, and is the only way to print ammo.
add: Bullets now cost chemicals. Normal ones cost aluminum, flash rounds cost aluminum and sulfur, and rubber rounds cost material plastic.
/:cl:

Please kill me. None of this worked as a child of the autolathe so I just went the smartfridge way.