### PR TITLE
Making Unathi actually cold blooded

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -832,35 +832,34 @@
 					else					bodytemp.icon_state = "temp-4"
 			else
 				//TODO: precalculate all of this stuff when the species datum is created
-				var/base_temperature = species.body_temperature
-				if(base_temperature == null) //some species don't have a set metabolic temperature
-					base_temperature = (getSpeciesOrSynthTemp(HEAT_LEVEL_1) + getSpeciesOrSynthTemp(COLD_LEVEL_1))/2
+				if(species.base_temperature == null) //some species don't have a set metabolic temperature
+					species.base_temperature = (getSpeciesOrSynthTemp(HEAT_LEVEL_1) + getSpeciesOrSynthTemp(COLD_LEVEL_1))/2
 
 				var/temp_step
-				if (bodytemperature >= base_temperature)
-					temp_step = (getSpeciesOrSynthTemp(HEAT_LEVEL_1) - base_temperature)/4
+				if (bodytemperature >= species.base_temperature)
+					temp_step = (getSpeciesOrSynthTemp(HEAT_LEVEL_1) - species.base_temperature)/4
 
 					if (bodytemperature >= getSpeciesOrSynthTemp(HEAT_LEVEL_1))
 						bodytemp.icon_state = "temp4"
-					else if (bodytemperature >= base_temperature + temp_step*3)
+					else if (bodytemperature >= species.base_temperature + temp_step*3)
 						bodytemp.icon_state = "temp3"
-					else if (bodytemperature >= base_temperature + temp_step*2)
+					else if (bodytemperature >= species.base_temperature + temp_step*2)
 						bodytemp.icon_state = "temp2"
-					else if (bodytemperature >= base_temperature + temp_step*1)
+					else if (bodytemperature >= species.base_temperature + temp_step*1)
 						bodytemp.icon_state = "temp1"
 					else
 						bodytemp.icon_state = "temp0"
 
-				else if (bodytemperature < base_temperature)
-					temp_step = (base_temperature - getSpeciesOrSynthTemp(COLD_LEVEL_1))/4
+				else if (bodytemperature < species.base_temperature)
+					temp_step = (species.base_temperature - getSpeciesOrSynthTemp(COLD_LEVEL_1))/4
 
 					if (bodytemperature <= getSpeciesOrSynthTemp(COLD_LEVEL_1))
 						bodytemp.icon_state = "temp-4"
-					else if (bodytemperature <= base_temperature - temp_step*3)
+					else if (bodytemperature <= species.base_temperature - temp_step*3)
 						bodytemp.icon_state = "temp-3"
-					else if (bodytemperature <= base_temperature - temp_step*2)
+					else if (bodytemperature <= species.base_temperature - temp_step*2)
 						bodytemp.icon_state = "temp-2"
-					else if (bodytemperature <= base_temperature - temp_step*1)
+					else if (bodytemperature <= species.base_temperature - temp_step*1)
 						bodytemp.icon_state = "temp-1"
 					else
 						bodytemp.icon_state = "temp0"

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -118,6 +118,8 @@
 	var/hazard_low_pressure = HAZARD_LOW_PRESSURE     			// Dangerously low pressure.
 	var/body_temperature = 310.15	                			//Species will try to stabilize at this temperature.
 	                                                  			// (also affects temperature processing)
+	var/base_temperature = 310.15								//Should remain the same as body temp except in fringe cases (cold blooded, etc)
+																//Called in life.dm one level above
 
 	var/heat_discomfort_level = 315                   			// Aesthetic messages about feeling warm.
 	var/cold_discomfort_level = 285                   			// Aesthetic messages about feeling chilly.

--- a/code/modules/mob/living/carbon/human/species/station/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/station/machine.dm
@@ -35,6 +35,7 @@
 	heat_level_3 = SYNTH_HEAT_LEVEL_3
 
 	body_temperature = null
+	base_temperature = null
 	passive_temp_gain = 5  // This should cause IPCs to stabilize at ~80 C in a 20 C environment.
 
 	species_flags = SPECIES_FLAG_NO_SCAN | SPECIES_FLAG_NO_PAIN | SPECIES_FLAG_NO_POISON

--- a/code/modules/mob/living/carbon/human/species/station/phorosian.dm
+++ b/code/modules/mob/living/carbon/human/species/station/phorosian.dm
@@ -45,6 +45,7 @@
 
 
 	body_temperature = 330
+	base_temperature = 330
 	heat_discomfort_level = 360                   // Aesthetic messages about feeling warm.
 	cold_discomfort_level = 250
 	heat_discomfort_strings = list(

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -107,6 +107,9 @@
 
 	min_age = 18
 	max_age = 260
+	
+	body_temperature = null
+	base_temperature = 293
 
 	blurb = "A heavily reptillian species, Unathi (or 'Sinta as they call themselves) hail from the \
 	Uuosa-Eso system, which roughly translates to 'burning mother'.<br/><br/>Coming from a harsh, radioactive \


### PR DESCRIPTION
<!-- 
!!IMPORTANT!!
Changes must be reviewed and approved by a developer before being merged.

If a developer has approved your PR, any other developer may immediately merge it, or the same developer may merge it after 24 hours.

A developer may not merge their own PR without the approval of two other developers.

Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Unathi are now cold blooded, with their body temperature completely dictated by the temperature of the room and presumably the protectiveness of the clothing they wear (should temperatures suddenly drop). The calculation for when the thermometer warning would pop up was a bit wonky and set Unathi's base temperature to 170 Fahrenheit, causing it to more or less permanently be present, so the var was worked down a level and coded for each species individually to allow more direct control over this. The only other two species with a different base body temperature, phorosians and the unimplemented IPCs, were changed to include the vars, and should be unaffected.

Coincidentally, medbay staff can now murder lizards with stasis, as god intended.