### PR TITLE
Fabricator Tweaks

### DIFF
--- a/code/modules/research/fabricator.dm
+++ b/code/modules/research/fabricator.dm
@@ -1,9 +1,8 @@
 /*
 Fabricators
-
-A reworked and modular system intended to differentiate the production of items from RnD through specialized machines, as well as simply giving them a nicer
+A reworked and modular system intended to differentiate the production of items from RnD through specialized machines, in addition to giving them a nicer
 interface. It is designed for subtypes to be easily created with minimal changes. New fabricators should be placed under the fabricators sub-folder, as well
-as their designs, in a single .dm file. voidsuit_fabricator.dm can be used as an example, and is entirely commented
+as their designs, in a single .dm file. voidsuit_fabricator.dm is an entirely commented example.
 */
 
 /obj/machinery/fabricator
@@ -12,8 +11,7 @@ as their designs, in a single .dm file. voidsuit_fabricator.dm can be used as an
 	desc = "A machine used for the production of various items"
 	var/obj/item/weapon/circuitboard/circuit = /obj/item/weapon/circuitboard/fabricator
 	var/build_type = PROTOLATHE
-	var/list/materials = list(DEFAULT_WALL_MATERIAL = 0, "glass" = 0, "gold" = 0, "plasteel" = 0, "osmium-carbide plasteel" = 0, "platinum" = 0, "tungsten" = 0)
-	req_access = list(core_access_science_programs)
+	req_access = list()
 
 	// Things that CAN be adjusted, but are okay to leave as default
 	icon_state = 			"fab-idle"
@@ -35,6 +33,7 @@ as their designs, in a single .dm file. voidsuit_fabricator.dm can be used as an
 	var/speed = 1
 	var/mat_efficiency = 1
 
+	var/list/materials = list()
 	var/res_max_amount = 200000
 	var/datum/research/files
 	var/list/datum/design/queue = list()
@@ -210,7 +209,7 @@ as their designs, in a single .dm file. voidsuit_fabricator.dm can be used as an
 				materials[material] += amnt
 				stack.use(1)
 				count++
-			to_chat(user, "You insert [count] [count==1 ? stack_singular : stack_plural] into the fabricator.")// 0 steel sheets, 1 steel sheet, 2 steel sheets, etc
+			to_chat(user, "You insert [count] [count == 1 ? stack_singular : stack_plural] into the fabricator.")// 0 steel sheets, 1 steel sheet, 2 steel sheets, etc
 	else
 		to_chat(user, "The fabricator cannot hold more [stack_plural].")// use the plural form even if the given sheet is singular
 
@@ -299,13 +298,13 @@ as their designs, in a single .dm file. voidsuit_fabricator.dm can be used as an
 		var/datum/design/D = files.known_designs[i]
 		if(!D.build_path || !(D.build_type && D.build_type == build_type))
 			continue
-		. += list(list("name" = D.name, "id" = i, "category" = D.category, "resourses" = get_design_resourses(D), "time" = get_design_time(D)))
+		. += list(list("name" = D.name, "id" = i, "category" = D.category, "resources" = get_design_resources(D), "time" = get_design_time(D)))
 
 /obj/machinery/fabricator/proc/CallReagentName(var/reagent_type)
 	var/datum/reagent/R = reagent_type
 	return ispath(reagent_type, /datum/reagent) ? initial(R.name) : "Unknown"
 
-/obj/machinery/fabricator/proc/get_design_resourses(var/datum/design/D)
+/obj/machinery/fabricator/proc/get_design_resources(var/datum/design/D)
 	var/list/F = list()
 	for(var/T in D.materials)
 		F += "[capitalize(T)]: [D.materials[T] * mat_efficiency]"
@@ -319,10 +318,23 @@ as their designs, in a single .dm file. voidsuit_fabricator.dm can be used as an
 /obj/machinery/fabricator/proc/update_categories()
 	categories = list()
 	if(files)
+		var/list/design_materials = list()
 		for(var/datum/design/D in files.known_designs)
 			if(!D.build_path || !(D.build_type && D.build_type == build_type))
 				continue
 			categories |= D.category
+
+			for(var/material in D.materials) // Iterating over the Designs' materials so that we know what should be able to be inserted
+				design_materials |= material
+				design_materials[material] = 0 // Prevents material count from appearing as null instead of 0
+
+		for(var/material in materials)
+			if(!(material in design_materials))
+				eject_materials(material, -1) // Dump all the materials not used in designs so that players don't use materials on code changes.
+
+		materials |= design_materials
+		materials &= design_materials
+
 		if(!category || !(category in categories) && LAZYLEN(categories))
 			category = categories[1]
 

--- a/code/modules/research/fabricators/ammo_fabricator.dm
+++ b/code/modules/research/fabricators/ammo_fabricator.dm
@@ -3,14 +3,13 @@
 	desc = "A machine used for the production of ammunitions of many calibers."
 	circuit = /obj/item/weapon/circuitboard/fabricator/ammofab
 	build_type = AMMOFAB
-	materials = list(DEFAULT_WALL_MATERIAL = 0, "glass" = 0, "plastic" = 0)
 
 	icon_state = 	 "circuitfab-idle"
 	icon_idle = 	 "circuitfab-idle"
 	icon_open = 	 "circuitfab-o"
 	overlay_active = "circuitfab-active"
+	metal_load_anim = FALSE
 
-	metal_load_anim = TRUE
 	has_reagents = TRUE
 
 ////////////////////////////////////////////////////

--- a/code/modules/research/fabricators/circuit_fabricator.dm
+++ b/code/modules/research/fabricators/circuit_fabricator.dm
@@ -1,18 +1,17 @@
 /obj/machinery/fabricator/circuit_fabricator
-	// Things that must be adjusted for each fabricator
 	name = "Circuit Imprinter"
 	desc = "A machine used for the production of circuits."
+	req_access = list(core_access_science_programs)
 	circuit = /obj/item/weapon/circuitboard/fabricator/circuitfab
 	build_type = CIRCUITFAB
-	materials = list(DEFAULT_WALL_MATERIAL = 0, "glass" = 0)
 
 	icon_state = 	 "circuitfab-idle"
 	icon_idle = 	 "circuitfab-idle"
 	icon_open = 	 "circuitfab-o"
 	overlay_active = "circuitfab-active"
-	metal_load_anim = 0
+	metal_load_anim = FALSE
 
-	has_reagents = 1
+	has_reagents = TRUE
 
 ////////////////////////////////////////////////////
 //////////////////////DESIGNS///////////////////////

--- a/code/modules/research/fabricators/mech_fabricator.dm
+++ b/code/modules/research/fabricators/mech_fabricator.dm
@@ -1,10 +1,9 @@
 /obj/machinery/fabricator/mecha_part_fabricator
-	// Things that must be adjusted for each fabricator
 	name = "Exosuit Fabricator"
 	desc = "A machine used for construction of robotics and mechas."
+	req_access = list(core_access_science_programs)
 	circuit = /obj/item/weapon/circuitboard/fabricator/mechfab
 	build_type = MECHFAB
-	materials = list(DEFAULT_WALL_MATERIAL = 0, "glass" = 0, "gold" = 0, "silver" = 0, "diamond" = 0, "phoron" = 0, "uranium" = 0)
 
 ////////////////////////////////////////////////////
 //////////////////////DESIGNS///////////////////////

--- a/code/modules/research/fabricators/voidsuit_fabricator.dm
+++ b/code/modules/research/fabricators/voidsuit_fabricator.dm
@@ -4,10 +4,7 @@
 	desc = "A machine used for the production of voidsuits and other spacesuits" // Self-explanatory
 	circuit = /obj/item/weapon/circuitboard/fabricator/voidfab // Circuit for the machine. These, as well as their designs, should be defined in fabricator_circuits.dm
 	build_type = VOIDFAB // The identifer for what gets built in what fabricator. A new one *MUST* be defined in _defines/research.dm for each fabricator.
-						 // More than one can be assigned per design, however, if you want something to be able to be built in more than one fabricator eg. Power Cells
-
- 	// The materials used in the fabrication of various goods. Generally you'll need to adapt this for each fabricator. To add a material, use its name var
-	materials = list(DEFAULT_WALL_MATERIAL = 0, "glass" = 0, "cloth" = 0, "plasteel" = 0, "osmium-carbide plasteel" = 0, "platinum" = 0, "tungsten" = 0)
+						 					 // More than one can be assigned per design, however, if you want something to be able to be built in more than one fabricator eg. Power Cells
 
 	// Things that CAN be adjusted, but are okay to leave as default
 	// Icon states - if you want your fabricator to use a special icon, place it in fabricators.dmi following these naming conventions.

--- a/nano/templates/fabricator.tmpl
+++ b/nano/templates/fabricator.tmpl
@@ -18,7 +18,7 @@
 					{{:helper.link(value.name, null, {'build' : value.id})}}
 				</div>
 				<div class="itemContentMedium">
-					{{:value.resourses}}, {{:value.time}}
+					{{:value.resources}}, {{:value.time}}
 				</div>
 			</div>
 		{{/if}}


### PR DESCRIPTION
Fabricators now dynamically adjust materials available to be inserted based off their designs. If a fabricator somehow loses all designs with a certain material, the respective material will be ejected as a stack.

Removes the Ammo Fabricator's access

Fixes the 'resourses' spelling error before I lost my mind.