### PR TITLE
Reverts/restores any armor value changes caused by auto-tailor PR

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -51,9 +51,14 @@
 	desc = "A hood worn by the followers of Nar-Sie."
 	flags_inv = HIDEFACE
 	body_parts_covered = HEAD
+	armor = list(melee = 30, bullet = 10, laser = 5,energy = 5, bomb = 0, bio = 0, rad = 0)
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.8 //That's a pretty cool opening in the hood. Also: Cloth making physical contact to the skull.
+
+/obj/item/clothing/head/culthood/costume
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 1.0
 
 /obj/item/clothing/head/culthood/magus
 	name = "magus helm"
@@ -61,9 +66,18 @@
 	desc = "A helm worn by the followers of Nar-Sie."
 	flags_inv = HIDEFACE | BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
+	armor = list(melee = 50, bullet = 40, laser = 30, energy = 20, bomb = 15, bio = 0, rad = 0)
+
+/obj/item/clothing/head/culthood/magus/costume
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 1.0
 
 /obj/item/clothing/head/culthood/alt
 	icon_state = "cult_hoodalt"
+
+/obj/item/clothing/head/culthood/alt/costume
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 1.0
 
 /obj/item/clothing/suit/cultrobes
 	name = "cult robes"
@@ -71,11 +85,20 @@
 	icon_state = "cultrobes"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	allowed = list(/obj/item/weapon/book/tome,/obj/item/weapon/melee/cultblade)
+	armor = list(melee = 35, bullet = 30, laser = 25,energy = 20, bomb = 25, bio = 10, rad = 0)
 	flags_inv = HIDEJUMPSUIT
 	siemens_coefficient = 0.6
 
+/obj/item/clothing/suit/cultrobes/costume
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 1.0
+
 /obj/item/clothing/suit/cultrobes/alt
 	icon_state = "cultrobesalt"
+
+/obj/item/clothing/suit/cultrobes/alt/costume
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 1.0
 
 /obj/item/clothing/suit/cultrobes/magusred
 	name = "magus robes"
@@ -83,6 +106,10 @@
 	icon_state = "magusred"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
+	armor = list(melee = 75, bullet = 50, laser = 55, energy = 40, bomb = 50, bio = 10, rad = 0)
+
+/obj/item/clothing/suit/cultrobes/magusred/costume
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/cultrobes/magusred/New()
 	..()

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -23,7 +23,12 @@
 /obj/item/clothing/gloves/insulated/cheap                             //Cheap Chinese Crap
 	desc = "These gloves are cheap copies of the coveted gloves, no way this can end badly."
 	name = "budget insulated gloves"
-	siemens_coefficient = 0.2	//i'm hoping this makes the gloves strong enough to keep you alive, but still too weak to casually work on live wiring
+	siemens_coefficient = 1			//Set to a default of 1, gets overridden in New()
+
+/obj/item/clothing/gloves/insulated/cheap/New()
+	..()
+	//average of 0.4, better than regular gloves' 0.75
+	siemens_coefficient = pick(0, 0.1, 0.2, 0.3, 0.4, 0.6, 1.3)
 
 /obj/item/clothing/gloves/forensic
 	desc = "Specially made gloves for forensic technicians. The luminescent threads woven into the material stand out under scrutiny."

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -33,11 +33,15 @@
 	name = "tactical helmet"
 	desc = "A tan helmet made from advanced ceramic. Comfortable and robust."
 	icon_state = "helmet_tac"
+	armor = list(melee = 50, bullet = 60, laser = 60, energy = 45, bomb = 30, bio = 0, rad = 0)
+	siemens_coefficient = 0.6
 
 /obj/item/clothing/head/helmet/merc
 	name = "combat helmet"
 	desc = "A heavily reinforced helmet painted with red markings. Feels like it could take a lot of punishment."
 	icon_state = "helmet_merc"
+	armor = list(melee = 70, bullet = 70, laser = 70, energy = 35, bomb = 30, bio = 0, rad = 0)
+	siemens_coefficient = 0.5
 
 /obj/item/clothing/head/helmet/riot
 	name = "riot helmet"
@@ -78,6 +82,7 @@
 	name = "\improper SWAT helmet"
 	desc = "They're often used by highly trained Swat Members."
 	icon_state = "helmet_merc"
+	armor = list(melee = 80, bullet = 60, laser = 50,energy = 25, bomb = 50, bio = 10, rad = 0)
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.5
@@ -87,20 +92,25 @@
 	desc = "<i>'Let the battle commence!'</i>"
 	icon_state = "thunderdome"
 	valid_accessory_slots = null
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 80, bullet = 60, laser = 50,energy = 10, bomb = 25, bio = 10, rad = 0)
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 1
+
+/obj/item/clothing/head/helmet/thunderdome/costume
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 
 /obj/item/clothing/head/helmet/gladiator
 	name = "gladiator helmet"
 	desc = "Ave, Imperator, morituri te salutant."
 	icon_state = "gladiator"
 	valid_accessory_slots = null
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 	body_parts_covered = HEAD|FACE
 	siemens_coefficient = 1
+
+/obj/item/clothing/head/helmet/gladiator/costume
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 
 /*
 /obj/item/clothing/head/helmet/tactical

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -20,7 +20,7 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	cold_protection = UPPER_TORSO|LOWER_TORSO
 	heat_protection = UPPER_TORSO|LOWER_TORSO
-	armor = list(melee = 25, bullet = 15, laser = 20, energy = 0, bomb = 5, bio = 0, rad = 0)
+	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/armor/vest/old/nt
 	name = "Nt security armor"
@@ -162,7 +162,7 @@
 	//item_state = "armor"
 	blood_overlay_type = "armor"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
-	armor = list(melee = 25, bullet = 15, laser = 20, energy = 0, bomb = 5, bio = 0, rad = 0)
+	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
 
 
 //Reactive armor
@@ -269,7 +269,7 @@
 	icon_state = "ertarmor_cmd"
 	item_state = "armor"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-	armor = list(melee = 40, bullet = 40, laser = 40, energy = 25, bomb = 30, bio = 0, rad = 0)
+	armor = list(melee = 60, bullet = 60, laser = 60, energy = 40, bomb = 20, bio = 0, rad = 0)
 
 //Security
 /obj/item/clothing/suit/armor/vest/ert/security
@@ -295,7 +295,7 @@
 	desc = "An armor vest made of synthetic fibers."
 	icon_state = "kvest"
 	item_state = "armor"
-	armor = list(melee = 30, bullet = 30, laser = 40, energy = 10, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 30, bullet = 15, laser = 40, energy = 10, bomb = 25, bio = 0, rad = 0)
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
 
 /obj/item/clothing/suit/armor/vest/nt

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -95,7 +95,10 @@
 /obj/item/clothing/suit/bio_suit/plaguedoctorsuit
 	name = "Plague doctor suit"
 	desc = "It protected doctors from the Black Death, back then. You bet your arse it's gonna help you against viruses."
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	icon_state = "plaguedoctor"
 	//item_state = "bio_suit"
 	flags_inv = HIDEGLOVES|HIDEJUMPSUIT|HIDETAIL
+
+/obj/item/clothing/suit/bio_suit/plaguedoctorsuit/costume
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 1.0

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -98,10 +98,17 @@
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|ARMS
 	allowed = list(/obj/item/weapon/tank/emergency,/obj/item/device/flashlight,/obj/item/weapon/gun/energy,/obj/item/weapon/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/weapon/flame/lighter,/obj/item/device/taperecorder)
+	armor = list(melee = 50, bullet = 10, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/storage/det_trench/grey
 	name = "grey trenchcoat"
 	icon_state = "detective2"
+
+/obj/item/clothing/suit/storage/det_trench/noarmor
+	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
+
+/obj/item/clothing/suit/storage/det_trench/grey/noarmor
+	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 
 //Forensics
 /obj/item/clothing/suit/storage/forensics
@@ -110,6 +117,7 @@
 	item_state = "det_suit"
 	body_parts_covered = UPPER_TORSO|ARMS
 	allowed = list(/obj/item/weapon/tank/emergency,/obj/item/device/flashlight,/obj/item/weapon/gun/energy,/obj/item/weapon/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/device/taperecorder)
+	armor = list(melee = 10, bullet = 10, laser = 15, energy = 10, bomb = 0, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/storage/forensics/red
 	name = "red jacket"
@@ -120,6 +128,12 @@
 	name = "blue jacket"
 	desc = "A blue forensics technician jacket."
 	icon_state = "forensics_blue"
+
+/obj/item/clothing/suit/storage/forensics/red/noarmor
+	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
+
+/obj/item/clothing/suit/storage/forensics/blue/noarmor
+	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 
 //Engineering
 /obj/item/clothing/suit/storage/hazardvest

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -112,6 +112,16 @@
 /obj/item/clothing/head/wizard/fake
 	siemens_coefficient = 1.0
 
+/obj/item/clothing/suit/wizrobe/old/fake
+	name = "wizard robe"
+	desc = "A rather dull, blue robe meant to mimick real wizard robes."
+	icon_state = "wizard"
+	item_state = "wizrobe"
+	gas_transfer_coefficient = 1
+	permeability_coefficient = 1
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 1.0
+
 /obj/item/clothing/suit/wizrobe/fake
 	name = "wizard robe"
 	desc = "A rather dull, blue robe meant to mimick real wizard robes."

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -6,7 +6,8 @@
 		slot_l_hand_str = "wizhat",
 		slot_r_hand_str = "wizhat",
 		)
-	siemens_coefficient = 1.0
+	//Not given any special protective value since the magic robes are full-body protection --NEO
+	siemens_coefficient = 0.8
 	body_parts_covered = 0
 	wizard_garb = 1
 
@@ -60,7 +61,11 @@
 	desc = "A magnificant, gem-lined robe that seems to radiate power."
 	icon_state = "wizard"
 	item_state = "wizrobe"
+	gas_transfer_coefficient = 0.01 // IT'S MAGICAL OKAY JEEZ +1 TO NOT DIE
+	permeability_coefficient = 0.01
+	armor = list(melee = 30, bullet = 20, laser = 20,energy = 20, bomb = 20, bio = 20, rad = 20)
 	allowed = list(/obj/item/weapon/teleportation_scroll)
+	siemens_coefficient = 0.8
 	wizard_garb = 1
 
 /obj/item/clothing/suit/wizrobe/red
@@ -103,21 +108,75 @@
 	item_state = "gentlecoat"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 
+//Cosmetic wizard wear below
+/obj/item/clothing/head/wizard/fake
+	siemens_coefficient = 1.0
+
 /obj/item/clothing/suit/wizrobe/fake
 	name = "wizard robe"
 	desc = "A rather dull, blue robe meant to mimick real wizard robes."
 	icon_state = "wizard-fake"
 	item_state = "wizrobe"
+	gas_transfer_coefficient = 1
+	permeability_coefficient = 1
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 1.0
+
+/obj/item/clothing/head/wizard/red/fake
+	siemens_coefficient = 1.0
+
+/obj/item/clothing/suit/wizrobe/red/fake
+	gas_transfer_coefficient = 1
+	permeability_coefficient = 1
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 1.0
 
 /obj/item/clothing/head/wizard/marisa/fake
 	name = "Witch Hat"
 	desc = "Strange-looking hat-wear, makes you want to cast fireballs."
 	icon_state = "marisa"
+	siemens_coefficient = 1.0
 
 /obj/item/clothing/suit/wizrobe/marisa/fake
 	name = "Witch Robe"
 	desc = "Magic is all about the spell power, ZE!"
 	icon_state = "marisa"
 	item_state = "marisarobe"
+	gas_transfer_coefficient = 1
+	permeability_coefficient = 1
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 1.0
 
+/obj/item/clothing/head/wizard/magus/fake
+	siemens_coefficient = 1.0
+
+/obj/item/clothing/suit/wizrobe/magusblue/fake
+	gas_transfer_coefficient = 1
+	permeability_coefficient = 1
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 1.0
+
+/obj/item/clothing/suit/wizrobe/magusred/fake
+	gas_transfer_coefficient = 1
+	permeability_coefficient = 1
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 1.0
+
+/obj/item/clothing/head/wizard/amp/fake
+	siemens_coefficient = 1.0
+
+/obj/item/clothing/suit/wizrobe/psypurple/fake
+	gas_transfer_coefficient = 1
+	permeability_coefficient = 1
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 1.0
+
+/obj/item/clothing/head/wizard/cap/fake
+	siemens_coefficient = 1.0
+
+/obj/item/clothing/suit/wizrobe/gentlecoat/fake
+	gas_transfer_coefficient = 1
+	permeability_coefficient = 1
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 1.0

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -68,7 +68,7 @@
 	name = "tactical armor plate"
 	desc = "A medium armor plate with additional ablative coating. Attaches to a plate carrier."
 	icon_state = "armor_tactical"
-	armor = list(melee = 40, bullet = 40, laser = 40, energy = 25, bomb = 30, bio = 0, rad = 0)
+	armor = list(melee = 40, bullet = 40, laser = 60, energy = 35, bomb = 30, bio = 0, rad = 0)
 
 /obj/item/clothing/accessory/armorplate/merc
 	name = "heavy armor plate"

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -101,6 +101,8 @@
 		slot_l_hand_str = "det_hat",
 		slot_r_hand_str = "det_hat",
 		)
+	armor = list(melee = 50, bullet = 5, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 0.9
 	flags_inv = BLOCKHEADHAIR
 
 /obj/item/clothing/head/det/attack_self(mob/user)
@@ -112,6 +114,13 @@
 	icon_state = "detective2"
 	desc = "A grey fedora - either the cornerstone of a detective's style or a poor attempt at looking cool, depending on the person wearing it."
 
+/obj/item/clothing/head/det/noarmor
+	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 1.0
+
+/obj/item/clothing/head/det/grey/noarmor
+	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 1.0
 
 /*
  * Head of Security

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -93,7 +93,7 @@
 	icon_state = "ert_uniform"
 	item_state = "bl_suit"
 	worn_state = "ert_uniform"
-	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.9
 
 /obj/item/clothing/under/space

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -5,7 +5,7 @@
 	item_state = "bl_suit"
 	worn_state = "syndicate"
 	has_sensor = 0
-	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 10, bullet = 10, laser = 10,energy = 0, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.9
 
 //only keeping because of arcade reward

--- a/code/modules/research/fabricators/autotailor_accessories.dm
+++ b/code/modules/research/fabricators/autotailor_accessories.dm
@@ -780,12 +780,6 @@
 	build_path = /obj/item/clothing/gloves/insulated
 	materials = list("leather" = 2000, "titanium" = 5000)	//not sure if this generates on roid, change if not
 
-/datum/design/item/autotailor/accessories/gloves/eng_cheap
-	name = "Insulated gloves - cheap"
-	id = "eng_cheap"
-	build_path = /obj/item/clothing/gloves/insulated/cheap
-	materials = list("leather" = 2000, DEFAULT_WALL_MATERIAL = 10000)
-
 /datum/design/item/autotailor/accessories/gloves/forensic
 	name = "Forensic gloves"
 	id = "forensic"
@@ -1040,7 +1034,7 @@
 /datum/design/item/autotailor/accessories/hats/beret_grey
 	name = "Flat cap - grey"
 	id = "flat_grey"
-	build_path = /obj/item/clothing/head/wizard/cap
+	build_path = /obj/item/clothing/head/wizard/cap/fake
 	materials = list("leather" = 500)
 
 /datum/design/item/autotailor/accessories/hats/trilby_blue
@@ -1058,13 +1052,13 @@
 /datum/design/item/autotailor/accessories/hats/fedora_grey
 	name = "Fedora - grey"
 	id = "fedora_grey"
-	build_path = /obj/item/clothing/head/det/grey
+	build_path = /obj/item/clothing/head/det/grey/noarmor
 	materials = list("leather" = 500)
 
 /datum/design/item/autotailor/accessories/hats/fedora_brown
 	name = "Fedora - brown"
 	id = "fedora_brown"
-	build_path = /obj/item/clothing/head/det
+	build_path = /obj/item/clothing/head/det/noarmor
 	materials = list("leather" = 500)
 
 /datum/design/item/autotailor/accessories/hats/bowler_black

--- a/code/modules/research/fabricators/autotailor_nonstandard.dm
+++ b/code/modules/research/fabricators/autotailor_nonstandard.dm
@@ -243,7 +243,7 @@
 /datum/design/item/autotailor/nonstandard/costume/gladiator_head
 	name = "Gladiator's helmet"
 	id = "gladiator_head"
-	build_path = /obj/item/clothing/head/helmet/gladiator
+	build_path = /obj/item/clothing/head/helmet/gladiator/costume
 	materials = list(DEFAULT_WALL_MATERIAL = 2000)
 
 /datum/design/item/autotailor/nonstandard/costume/schoolgirl
@@ -396,40 +396,40 @@
 /datum/design/item/autotailor/nonstandard/costume/armored_cult
 	name = "cultist robes - armored"
 	id = "armored_cult"
-	build_path = /obj/item/clothing/suit/cultrobes
+	build_path = /obj/item/clothing/suit/cultrobes/costume
 	materials = list("leather" = 5000, DEFAULT_WALL_MATERIAL = 500)
 
 /datum/design/item/autotailor/nonstandard/costume/sorcery_cult_r
-	name = "cultist roves - red sorcerer"
+	name = "cultist robes - red sorcerer"
 	id = "sorcery_cult_r"
-	build_path = /obj/item/clothing/suit/cultrobes/magusred
+	build_path = /obj/item/clothing/suit/cultrobes/magusred/costume
 
 /datum/design/item/autotailor/nonstandard/costume/sorcery_cult_b
-	name = "cultist roves - blue sorcerer"
+	name = "cultist robes - blue sorcerer"
 	id = "sorcery_cult_b"
-	build_path = /obj/item/clothing/suit/wizrobe/magusblue
+	build_path = /obj/item/clothing/suit/wizrobe/magusblue/fake
 
 /datum/design/item/autotailor/nonstandard/costume/cult
 	name = "cultist robes - standard"
 	id = "cult"
-	build_path = /obj/item/clothing/suit/cultrobes/alt
+	build_path = /obj/item/clothing/suit/cultrobes/alt/costume
 
 /datum/design/item/autotailor/nonstandard/costume/cult_head_grey
 	name = "cultist hood - grey"
 	id = "cult_head_grey"
-	build_path = /obj/item/clothing/head/culthood/alt
+	build_path = /obj/item/clothing/head/culthood/alt/costume
 	materials = list("cloth" = 2000)
 
 /datum/design/item/autotailor/nonstandard/costume/cult_head_red
 	name = "cultist hood - red"
 	id = "cult_head_red"
-	build_path = /obj/item/clothing/head/culthood
+	build_path = /obj/item/clothing/head/culthood/costume
 	materials = list("cloth" = 2000)
 
 /datum/design/item/autotailor/nonstandard/costume/cult_head_warrior
 	name = "cultist helmet - warrior"
 	id = "cult_head_warrior"
-	build_path = /obj/item/clothing/head/culthood/magus
+	build_path = /obj/item/clothing/head/culthood/magus/costume
 	materials = list("cloth" = 2000)
 
 /datum/design/item/autotailor/nonstandard/costume/red_suit_armor
@@ -447,7 +447,7 @@
 /datum/design/item/autotailor/nonstandard/costume/armor_suit_head
 	name = "Armored suit helmet"
 	id = "green_suit_head"
-	build_path = /obj/item/clothing/head/helmet/thunderdome
+	build_path = /obj/item/clothing/head/helmet/thunderdome/costume
 	materials = list(DEFAULT_WALL_MATERIAL = 2000)
 
 /datum/design/item/autotailor/nonstandard/costume/cardboard
@@ -465,24 +465,24 @@
 /datum/design/item/autotailor/nonstandard/costume/purple_robe
 	name = "Robes - embelished purple"
 	id = "purple_robe"
-	build_path = /obj/item/clothing/suit/wizrobe/psypurple
+	build_path = /obj/item/clothing/suit/wizrobe/psypurple/fake
 	materials = list("cloth" = 10000, "phoron" = 4000)
 
 /datum/design/item/autotailor/nonstandard/costume/purple_robe_head
 	name = "Robes - embelished purple head"
 	id = "purple_robe_head"
-	build_path = /obj/item/clothing/head/wizard/amp
+	build_path = /obj/item/clothing/head/wizard/amp/fake
 	materials = list("cloth" = 2000, "phoron" = 1000)
 
 /datum/design/item/autotailor/nonstandard/costume/red_robe
 	name = "Robes - red"
 	id = "red_robe"
-	build_path = /obj/item/clothing/suit/wizrobe/red
+	build_path = /obj/item/clothing/suit/wizrobe/red/fake
 
 /datum/design/item/autotailor/nonstandard/costume/red_robe_head
 	name = "Robes - red hat"
 	id = "red_robe_hat"
-	build_path = /obj/item/clothing/head/wizard/red
+	build_path = /obj/item/clothing/head/wizard/red/fake
 	materials = list("cloth" = 2000)
 
 /datum/design/item/autotailor/nonstandard/costume/blue_basic_robe
@@ -493,7 +493,7 @@
 /datum/design/item/autotailor/nonstandard/costume/blue_robe
 	name = "Robes - blue"
 	id = "blue_robe"
-	build_path = /obj/item/clothing/suit/wizrobe
+	build_path = /obj/item/clothing/suit/wizrobe/fake
 
 /datum/design/item/autotailor/nonstandard/costume/blue_robe_head
 	name = "Robes - blue hat"
@@ -663,7 +663,7 @@
 /datum/design/item/autotailor/nonstandard/costume/plague_doc
 	name = "Plague doctor suit"
 	id = "plague_doc"
-	build_path = /obj/item/clothing/suit/bio_suit/plaguedoctorsuit
+	build_path = /obj/item/clothing/suit/bio_suit/plaguedoctorsuit/costume
 	materials = list("leather" = 20000)
 
 /datum/design/item/autotailor/nonstandard/costume/plague_doc_hat

--- a/code/modules/research/fabricators/autotailor_nonstandard.dm
+++ b/code/modules/research/fabricators/autotailor_nonstandard.dm
@@ -488,7 +488,7 @@
 /datum/design/item/autotailor/nonstandard/costume/blue_basic_robe
 	name = "Robes - basic blue"
 	id = "blue_basic_robe"
-	build_path = /obj/item/clothing/suit/wizrobe/fake
+	build_path = /obj/item/clothing/suit/wizrobe/old/fake
 
 /datum/design/item/autotailor/nonstandard/costume/blue_robe
 	name = "Robes - blue"

--- a/code/modules/research/fabricators/autotailor_standard.dm
+++ b/code/modules/research/fabricators/autotailor_standard.dm
@@ -1246,22 +1246,22 @@
 /datum/design/item/autotailor/suit/overcoats/brown_trench
 	name = "Trenchcoat - brown"
 	id = "brown_trench"
-	build_path = /obj/item/clothing/suit/storage/det_trench
+	build_path = /obj/item/clothing/suit/storage/det_trench/noarmor
 
 /datum/design/item/autotailor/suit/overcoats/grey_trench
 	name = "Trenchcoat - grey"
 	id = "grey_trench"
-	build_path = /obj/item/clothing/suit/storage/det_trench/grey
+	build_path = /obj/item/clothing/suit/storage/det_trench/grey/noarmor
 
 /datum/design/item/autotailor/suit/overcoats/red_casual
 	name = "Casual jacket - red"
 	id = "red_casual"
-	build_path = /obj/item/clothing/suit/storage/forensics/red
+	build_path = /obj/item/clothing/suit/storage/forensics/red/noarmor
 
 /datum/design/item/autotailor/suit/overcoats/blue_casual
 	name = "Casual jacket - blue"
 	id = "blue_casual"
-	build_path = /obj/item/clothing/suit/storage/forensics/blue
+	build_path = /obj/item/clothing/suit/storage/forensics/blue/noarmor
 
 /datum/design/item/autotailor/suit/overcoats/white_suitjacket	//can use custom colors
 	name = "Suit jacket - white"
@@ -1396,7 +1396,7 @@
 /datum/design/item/autotailor/suit/overcoats/gentle_coat
 	name = "Gentleman's coat"
 	id = "gentle_coat"
-	build_path = /obj/item/clothing/suit/wizrobe/gentlecoat
+	build_path = /obj/item/clothing/suit/wizrobe/gentlecoat/fake
 
 /datum/design/item/autotailor/suit/overcoats/priest_robes
 	name = "Holiday Priest robes"

--- a/code/modules/research/fabricators/autotailor_tactical.dm
+++ b/code/modules/research/fabricators/autotailor_tactical.dm
@@ -36,6 +36,7 @@
 	name = "tactical turtleneck"
 	id = "turtleneck_def"
 	build_path = /obj/item/clothing/under/syndicate
+	materials = list("leather" = 5000, "plasteel" = 5000, "osmium-carbide plasteel" = 5000)
 
 /datum/design/item/autotailor/combat/under/hos_red
 	name = "Head of Security jumpsuit - red"
@@ -118,6 +119,7 @@
 	name = "ERT uniform"
 	id = "tactical_ert"
 	build_path = /obj/item/clothing/under/ert
+	materials = list("leather" = 5000, "plasteel" = 1000, "osmium-carbide plasteel" = 1000)
 
 /datum/design/item/autotailor/combat/under/pt_uniform
 	name = "TF PT uniform"
@@ -298,31 +300,31 @@
 	name = "armor vest - tactical"
 	id = "tact_vest"
 	build_path = /obj/item/clothing/suit/armor/vest
-	materials = list("leather" = 10000, DEFAULT_WALL_MATERIAL = 10000, "osmium-carbide plasteel" = 7500)
+	materials = list("leather" = 10000, DEFAULT_WALL_MATERIAL = 10000, "osmium-carbide plasteel" = 3000)
 
 /datum/design/item/autotailor/combat/barmour/tact_vest_nt	//NT item
 	name = "armor vest - tactical NT"
 	id = "tact_vest_nt"
 	build_path = /obj/item/clothing/suit/armor/vest/nt
-	materials = list("leather" = 10000, DEFAULT_WALL_MATERIAL = 10000, "osmium-carbide plasteel" = 7500)
+	materials = list("leather" = 10000, DEFAULT_WALL_MATERIAL = 10000, "osmium-carbide plasteel" = 3000)
 
 /datum/design/item/autotailor/combat/barmour/tact_vest_pcrc
 	name = "armor vest - tactical PCRC"
 	id = "tact_vest_pcrc"
 	build_path = /obj/item/clothing/suit/armor/vest/pcrc
-	materials = list("leather" = 10000, DEFAULT_WALL_MATERIAL = 10000, "osmium-carbide plasteel" = 7500)
+	materials = list("leather" = 10000, DEFAULT_WALL_MATERIAL = 10000, "osmium-carbide plasteel" = 3000)
 
 /datum/design/item/autotailor/combat/barmour/tact_vest_press
 	name = "armor vest - tactical press"
 	id = "tact_vest_press"
 	build_path = /obj/item/clothing/suit/armor/vest/press
-	materials = list("leather" = 10000, DEFAULT_WALL_MATERIAL = 10000, "osmium-carbide plasteel" = 7500)
+	materials = list("leather" = 10000, DEFAULT_WALL_MATERIAL = 10000, "osmium-carbide plasteel" = 3000)
 
 /datum/design/item/autotailor/combat/barmour/tact_brown
 	name = "armor vest - tactical brown"
 	id = "tact_brown"
 	build_path = /obj/item/clothing/suit/armor/vest/detective
-	materials = list("leather" = 10000, DEFAULT_WALL_MATERIAL = 10000, "osmium-carbide plasteel" = 7500)
+	materials = list("leather" = 10000, DEFAULT_WALL_MATERIAL = 10000, "osmium-carbide plasteel" = 3000)
 
 /datum/design/item/autotailor/combat/barmour/stab_vest
 	name = "armor vest - stab protection"
@@ -523,10 +525,10 @@
 	materials = list(DEFAULT_WALL_MATERIAL = 5000, "plasteel" = 5000)
 
 /datum/design/item/autotailor/combat/barmour/helmet_tan
-	name = "Helmet - tan"
+	name = "Helmet - tactical"
 	id = "helmet_tan"
 	build_path = /obj/item/clothing/head/helmet/tactical
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "plasteel" = 5000)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "plasteel" = 7000)
 
 /datum/design/item/autotailor/combat/barmour/helmet_navy
 	name = "Helmet - navy"
@@ -544,7 +546,7 @@
 	name = "Helmet - black w. red stripes"
 	id = "helmet_bl_redstripe"
 	build_path = /obj/item/clothing/head/helmet/merc
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, "plasteel" = 5000)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "plasteel" = 9000,  "osmium-carbide plasteel" = 5000)
 
 /datum/design/item/autotailor/combat/barmour/helmet_bl_redmark
 	name = "Helmet - black w. red markings"
@@ -618,7 +620,7 @@
 	name = "Chestplate - medium tan"
 	id = "chest_medtan"
 	build_path = /obj/item/clothing/accessory/armorplate/tactical
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "plasteel" = 7000, "osmium-carbide plasteel" = 7000)
+	materials = list(DEFAULT_WALL_MATERIAL = 10000, "plasteel" = 8000, "osmium-carbide plasteel" = 8000)
 
 /datum/design/item/autotailor/combat/modular_armor/chest_heavy
 	name = "Chestplate - heavy"

--- a/html/changelogs/ourpar-pr-1081.yml
+++ b/html/changelogs/ourpar-pr-1081.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.
+author: ourpar
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Restored any armor values caused by the recent autotailor PR"
+  - tweak: "Cheap insulated gloves were reverted to have RNG based shock absorption again"


### PR DESCRIPTION
There was some discussion on the discord about how unnecessary it was to have clothing value changes and the autotailor in a single PR, along with a request to restore the armor values to before the tailoring PR, it's pretty agreeable, so this pr "reverts" any armor value changes caused by PR https://github.com/Persistent-SS13/Persistent-Bay/pull/1076 

more specific list of what was changed:
- Antag clothing armor values were restored for their base item, instead the autotailor now prints out their own specific unarmored version for these items
- Combat clothing/helmets/vests have their armor values restored too, resource requirements to print these items were slightly changed to reflect the new values
- Cheap insulated gloves shock resistance were restored to their RNG values aswell, and they are no longer obtainable in the autotailor (since they have a 1/7 chance to be printed as perfect gloves)