### PR TITLE
Fix  runtime with sswireless

### DIFF
--- a/code/controllers/subsystems/SSwireless.dm
+++ b/code/controllers/subsystems/SSwireless.dm
@@ -55,7 +55,7 @@ SUBSYSTEM_DEF(wireless)
 /datum/controller/subsystem/wireless/proc/process_queue(var/list/process_connections, var/list/unsuccesful_connections)
 	while(process_connections.len)
 		var/datum/connection_request/C = process_connections[process_connections.len]
-		process_connections--
+		process_connections -= C
 		var/target_found = 0
 		for(var/datum/wifi/receiver/R in receiver_list)
 			if(R.id == C.id)


### PR DESCRIPTION
* someone had tried to remove entries from a list using a -- operator for some reasons, and it made the list turn into a number at one point. Fixed with the proper operation.

<!-- 
!!IMPORTANT!!
Changes must be reviewed and approved by a developer before being merged.

If a developer has approved your PR, any other developer may immediately merge it, or the same developer may merge it after 24 hours.

A developer may not merge their own PR without the approval of two other developers.

Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Fix for the runtime in sswireless with the random -- operator used to, I assume, attempt to pop a list, but instead cast it to a number. Replaced it with a -= instead to remove the element in the list. 