### PR TITLE
Refactored Designer DM-side

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -95,6 +95,8 @@
 			return global.SSprocessing;
 		if("SSradiation")
 			return global.SSradiation;
+		if("SSresearch")
+			return global.SSresearch;
 		if("SSshuttle")
 			return global.SSshuttle;
 		if("SSskybox")
@@ -395,6 +397,8 @@
 			return global.department_radio_keys;
 		if("description_icons")
 			return global.description_icons;
+		if("designer_system")
+			return global.designer_system;
 		if("diary")
 			return global.diary;
 		if("dna_activity_bounds")
@@ -1162,6 +1166,8 @@
 			global.SSprocessing=newval;
 		if("SSradiation")
 			global.SSradiation=newval;
+		if("SSresearch")
+			global.SSresearch=newval;
 		if("SSshuttle")
 			global.SSshuttle=newval;
 		if("SSskybox")
@@ -1462,6 +1468,8 @@
 			global.department_radio_keys=newval;
 		if("description_icons")
 			global.description_icons=newval;
+		if("designer_system")
+			global.designer_system=newval;
 		if("diary")
 			global.diary=newval;
 		if("dna_activity_bounds")
@@ -2181,6 +2189,7 @@
 	"SSplants",
 	"SSprocessing",
 	"SSradiation",
+	"SSresearch",
 	"SSshuttle",
 	"SSskybox",
 	"SSsun",
@@ -2331,6 +2340,7 @@
 	"department_accounts",
 	"department_radio_keys",
 	"description_icons",
+	"designer_system",
 	"diary",
 	"dna_activity_bounds",
 	"dna_genes",

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -209,7 +209,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/cmd_analyse_health_panel,
 	/client/proc/visualpower,
 	/client/proc/visualpower_remove,
-	/datum/admins/proc/generate_beacon,			//Generates the Nanotrasen faction beacon
+	/datum/admins/proc/generate_beacon,
 	/datum/designer_system/proc/delete_designs
 	)
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -209,7 +209,8 @@ var/list/admin_verbs_debug = list(
 	/client/proc/cmd_analyse_health_panel,
 	/client/proc/visualpower,
 	/client/proc/visualpower_remove,
-	/datum/admins/proc/generate_beacon			//Generates the Nanotrasen faction beacon
+	/datum/admins/proc/generate_beacon,			//Generates the Nanotrasen faction beacon
+	/datum/designer_system/proc/delete_designs
 	)
 
 var/list/admin_verbs_paranoid_debug = list(

--- a/code/modules/designer/canvas.dm
+++ b/code/modules/designer/canvas.dm
@@ -4,39 +4,24 @@
 	gender = NEUTER
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "canvas"
-	var/icon/icon_custom
-	var/list/pixel_list
-	var/datum/designer/design
-
 	var/icon_offset_x = 1
 	var/icon_offset_y = 1
 
-/obj/item/canvas/New()
-	design = new(source = src)
-	icon_custom = icon
-
 /obj/item/canvas/attack_self(mob/user)
-	design.pixel_width = 30
-	design.pixel_height = 30
-	design.Design(icon_custom, icon_offset_x, icon_offset_y)
-
-/obj/item/canvas/GetDesign(var/icon/ico, ckey)
-	if (!ico || !istype(ico) )
-		return
-	ico.Shift(EAST, icon_offset_x)
-	ico.Shift(SOUTH, icon_offset_y)
-	icon_custom = ico
-	overlays.Cut()
-	overlays += icon_custom
-
-	if (ckey)
-		designer_creator_ckey = ckey
-
+	if (!designer_unit)
+		designer_unit = new()
+	designer_unit.pixel_width = 30
+	designer_unit.pixel_height = 30
 	var/title_consent = input("Do you want to give it a title?", "Designer", "No") in list("Yes", "No")
 	if (title_consent == "Yes")
-		design.title = input("Title:", "Designer", "")
-		if (length(design.title) >= 1)
-			src.name = "\"[design.title]\""
+		designer_unit.title = input("Title:", "Designer", "")
+		if (length(designer_unit.title) >= 1)
+			src.name = "\"[designer_unit.title]\""
 			var/author_consent = input("Do you Also want to sign it?", "Designer", "Yes") in list("Yes", "No")
 			if (author_consent == "Yes")
 				src.name += " by [usr.real_name]"
+	designer_unit.Design(src, icon_offset_x, icon_offset_y)
+
+/obj/item/canvas/designer_update_icon()
+	overlays.Cut()
+	overlays += designer_unit.icon_custom

--- a/code/modules/designer/designer.dm
+++ b/code/modules/designer/designer.dm
@@ -1,46 +1,55 @@
 //Yet another spaget cooked by Stigma. The HTML file is at html/designer.html. -- https://github.com/ingles98
 
-/atom/var/designer_creator_ckey = "None - This icon wasn't created by the Designer feature."	//For blaming reasons
-/atom/proc/GetDesign(var/icon/design, var/ckey) //Adds a general proc so any atom may be able to hook into the designer feature.
+//Any proc can have a designer_unit attached. The way they handle it is highly derivative
+/atom/var/datum/designer_unit/designer_unit
 
-/obj/item/design_item //test item
-	name = "designs"
-	desc = "Test it out. ~Stigma"
-	gender = NEUTER
-	icon = 'icons/obj/bureaucracy.dmi'
-	icon_state = "paper"
-	var/icon/icon_custom
-	var/list/pixel_list
-	var/datum/designer/design
+//A general proc so any atom may be able to hook into the designer feature. It is called after a design change
+/atom/proc/designer_update_icon()
 
-/obj/item/design_item/New()
-	design = new(source = src)
+//Associates the target design to the current atom.
+/atom/proc/designer_associate(var/datum/designer_unit/design)
+	designer_unit = design
+	if (!(src in design.associated_atoms))
+		design.associated_atoms += src
 
-/obj/item/design_item/verb/Design()
-	set name = "Design tool by Stigma - DEBUG"
+//The global designer_system var. Stores all designs in its list/designs.
+var/global/datum/designer_system/designer_system = new()
+//The actual designer_system datum
+/datum/designer_system
+	var/list/designs = list()
+
+// Whenever a new design is created (probably when first creating a canvas item or anything else hooked to designer)
+// It calls our dear designer_system so it can be inserted on its designs list, and also get an unique ID.
+/datum/designer_system/proc/newDesign(var/datum/designer_unit/unit)
+	designs.Insert(designs.len +1, unit)
+	unit.id = designs.len -1 > 0 ? designs[designs.len -1].id +1 : 1
+
+//A DEBUG verb, more for admemeing than that to be honest.
+// Doesn't actually delete designs, it deletes their icons.
+/datum/designer_system/proc/delete_designs()
 	set category = "Debug"
-	design.pixel_width = text2num( input("Max Width:", "Designer DEBUG", 32) )
-	design.pixel_height = text2num( input("Max Width:", "Designer DEBUG", 32) )
-	design.Design(icon_custom)
+	set desc = "Deletes all designs made by an individual. (Only replaces the design's icons and updates atoms, does not delete them.)"
+	set name = "Designer: Delete Designs by Ckey"
 
-/obj/item/design_item/GetDesign(var/icon/ico, ckey)
-	if (!ico || !istype(ico) )
-		return
-	var/offset_x = text2num( input("Offset X:", "Designer DEBUG", 0) )
-	var/offset_y = text2num( input("Offset Y:", "Designer DEBUG", 0) )
-	ico.Shift(EAST, offset_x)
-	ico.Shift(SOUTH, offset_y)
-	icon_custom = ico
-	icon = icon_custom
+	var/ckey = input("Input the CKEY you want all associated designs removed:", "Designer", "")
+	var/count = 0
 
-	if (ckey)
-		designer_creator_ckey = ckey
+	usr << "Searching for designs made by ckey: [ckey]"
+	for (var/datum/designer_unit/design in designer_system.designs)
+		if (design.creator_ckey == lowertext(ckey))
+			design.delete_icon()
+			count++
+	usr << "[count] designs made by [ckey] have been purged, only their associated atoms were left behind."
 
-/datum/designer
+//Our dear design holder. Almost everything related to designer happens under this datum.
+/datum/designer_unit
+	var/id
+
 	var/pixel_width = 8
 	var/pixel_height = 8
 
-	var/atom/my_atom
+	var/icon_offset_x = 0
+	var/icon_offset_y = 0
 
 	var/list/colors
 	var/icon/icon_custom
@@ -48,12 +57,18 @@
 	var/creator_ckey
 	var/title = ""
 
-/datum/designer/New(source = null)
-	if (source)
-		my_atom = source
+	var/list/associated_atoms = list()
 
+//On new design_unit, add itself to the global list of designs.
+/datum/designer_unit/New()
+	designer_system.newDesign(src)
 
-/datum/designer/proc/Design(var/icon/icon_custom = null, offset_x = 0, offset_y = 0)
+//The general proc to use when you want to draw to this design_unit
+/datum/designer_unit/proc/Design(var/atom/source, offset_x = 0, offset_y = 0)
+	source.designer_associate(src)
+	icon_offset_x = offset_x
+	icon_offset_y = offset_y
+
 	usr << browse(file("html/designer.html"), "window=designer;size=600x400;can_close=1" )
 	sleep(5)
 	usr << output("href='?src=\ref[src];[pixel_width];[pixel_height]","designer.browser:getData")
@@ -73,7 +88,10 @@
 				pixel_list[x][y] = color
 		spawn(2) usr << output("[json_encode(pixel_list)]","designer.browser:getIconAsJSON")
 
-/datum/designer/Topic(href,href_list[])
+// Handles retrieval of pixel data from the client browser.
+// Not very optimized, but it actually happens very fast, i'd say instantly right after the browser is done processing the icon on its side.
+// Still conceptualizing an optimized alternative.
+/datum/designer_unit/Topic(href,href_list[])
 	switch(href_list["action"])
 		/*
 			The 'if("getIcon")' below is WIP and should never be executed. It is the response from the WIP
@@ -92,7 +110,6 @@
 					var/color = rgb(icon_array[x][y][0], icon_array[x][y][1], icon_array[x][y][2], icon_array[x][y][3])
 					processIcon(x,y,color)
 			finishIcon()
-
 		if ("pixel")
 			var/x = text2num(href_list["x"])
 			var/y = text2num(href_list["y"])
@@ -101,6 +118,7 @@
 			var/g = text2num(href_list["g"])
 			var/b = text2num(href_list["b"])
 			var/alpha = text2num(href_list["a"])
+
 			var/color = rgb(r,g,b,alpha)
 
 			processIcon(color,x,y)
@@ -110,13 +128,65 @@
 		if ("stop")
 			finishIcon()
 
-/datum/designer/proc/processIcon(var/color,var/x,var/y)
+//Processes individual pixel.
+/datum/designer_unit/proc/processIcon(var/color,var/x,var/y)
 	set background = 1
 	icon_custom.DrawBox(color,x, y)
 	sleep(-1)
 
-/datum/designer/proc/finishIcon()
+// When finishing the icon, it needs to flip around the Y axis cause the way we deal with
+// passing the icon data from BYOND to the client browser and back.
+// It applies the offsets and updates all associated atoms afterwards
+/datum/designer_unit/proc/finishIcon()
 	icon_custom.Flip(NORTH)
+	icon_custom.Shift(EAST, icon_offset_x)
+	icon_custom.Shift(SOUTH, icon_offset_y)
+	update_associated_atoms()
 
-	if (my_atom)
-		my_atom.GetDesign(icon_custom, ckey = creator_ckey)
+/datum/designer_unit/proc/update_associated_atoms()
+	for (var/atom/obj in associated_atoms)
+		obj.designer_update_icon()
+
+// General proc for replacing the icon. Currently replaces with a red 'X'.
+// Used for moderating purposes. Doesn't actually delete the associated atoms.
+/datum/designer_unit/proc/delete_icon()
+	icon_custom = new('icons/Testing/Zone.dmi',icon_state = "fullblock")
+	update_associated_atoms()
+
+// Same as delete_icon, but this time it actually deletes the design datum and ALL associated atoms.
+// WARNING USE WITH CAUTION
+/datum/designer_unit/proc/purge_atoms()
+	delete_icon()
+	for (var/atom/obj in associated_atoms)
+		qdel(obj)
+	designer_system.designs -= src
+	qdel(src)
+
+//-----------------------------------------------------------------------------------------
+
+// A debug item to test the designer system.
+/obj/item/design_item
+	name = "designs"
+	desc = "Test it out."
+	gender = NEUTER
+	icon = 'icons/obj/bureaucracy.dmi'
+	icon_state = "paper"
+
+/obj/item/design_item/verb/Design()
+	set name = "Design tool - DEBUG"
+	set category = "Debug"
+	if (!designer_unit)
+		designer_unit = new()
+	designer_unit.pixel_width = text2num( input("Max Width:", "Designer DEBUG", 32) )
+	designer_unit.pixel_height = text2num( input("Max Height:", "Designer DEBUG", 32) )
+	designer_unit.Design(src)
+
+/obj/item/design_item/verb/Clone()
+	set name = "Clone - DEBUG"
+	set category = "Debug"
+	var/obj/item/design_item/new_item = new(get_turf(src))
+	new_item.designer_associate(src.designer_unit)
+	new_item.designer_update_icon()
+
+/obj/item/design_item/designer_update_icon()
+	icon = designer_unit.icon_custom

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -242,7 +242,7 @@ function run_byond_tests {
         source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
     fi
     run_test_ci "check globals build" "python3 tools/GenerateGlobalVarAccess/gen_globals.py persistentss13.dme code/_helpers/global_access.dm"
-    run_test "check globals unchanged" "md5sum -c - <<< '88b6ad676f8ffd3179248b3471c8f1da *code/_helpers/global_access.dm'"
+    run_test "check globals unchanged" "md5sum -c - <<< '1bd4dee65e2484090d44f489fc3609cf *code/_helpers/global_access.dm'"
     run_test "build map unit tests" "scripts/dm.sh -DUNIT_TEST -M$MAP_PATH persistentss13.dme"
     run_test "check no warnings in build" "grep ', 0 warnings' build_log.txt"
     run_test "run unit tests" "DreamDaemon persistentss13.dmb -invisible -trusted -core 2>&1 | tee log.txt"


### PR DESCRIPTION
 - Added a global designer_system datum, which holds a list var "designs" with all designs there is. Also includes a debug proc for deleting designs by CKEY.
 - No longer uses additional atom vars other than a "designer_unit", which is a datum that represents the design.
 - "designer_unit" has a proc called "delete_designs" which replaces its icon_custom (design) with a placeholder icon, and a proc "purge_atoms" which does the same but also deletes any atom associated with the design, and deletes the design itself from existence.
 - Easier to use hooks and easier to read code for future maintainability.