### PR TITLE
Wilderness monster spawning handler

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -279,12 +279,12 @@
 				new_z = data.E_connect
 
 		else if (y <= TRANSITIONEDGE-1) 					// South
-			new_y = TRANSITIONEDGE + 1
+			new_y = world.maxy - TRANSITIONEDGE - 1
 			var/datum/zlevel_data/data = SSmazemap.map_data["[z]"]
 			if(data && data.S_connect)
 				new_z = data.S_connect
 		else if (y >= (world.maxy + 1 - TRANSITIONEDGE))	// North
-			new_y = world.maxy - TRANSITIONEDGE - 1
+			new_y = TRANSITIONEDGE + 1
 			var/datum/zlevel_data/data = SSmazemap.map_data["[z]"]
 			if(data && data.N_connect)
 				new_z = data.N_connect

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -126,6 +126,8 @@ var/const/enterloopsanity = 100
 
 	if(ismob(A))
 		var/mob/M = A
+		if (isliving(M) && M.stat != DEAD)
+			SSmazemap.map_data["[M.z]"].set_active()
 		if(!M.check_solid_ground())
 			inertial_drift(M)
 			//we'll end up checking solid ground again but we still need to check the other things.

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -24,6 +24,8 @@
 	var/clean_up_time = 0
 	var/last_found = 0
 
+	should_save = 0
+
 /mob/living/simple_animal/hostile/New()
 	..()
 	last_found = world.time
@@ -112,7 +114,7 @@
 	if(!Adjacent(target_mob))
 		return
 	if(attack_sound)
-		playsound(loc, attack_sound, 50, 1, 1)	
+		playsound(loc, attack_sound, 50, 1, 1)
 	if(isliving(target_mob))
 		var/mob/living/L = target_mob
 		L.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext,damtype,defense)


### PR DESCRIPTION
Also fixes the zlevel translation issue on the Y axis, which translated you to the other opposite end of the zlevel if you were traveling from North or South.

Still needs customization from each zlevel. For instance, the monsters that spawn, the amount, etc...
We could also make it chance based. (more chances of a specific mob than other)

Right now, it spawns at max 5 carps in the wild. Every three minutes it will check for activity on the zlevels. IF the zlevel is active, respawn carps until they are five again if they werent already. If they are inactive in the current check, they will be set to DORMANT, in which no more spawns will be made. IF they are inactive again in the next check, they will be effectively set to INACTIVE in which case any mobs in there will be frozen (their AI will no longer process) until the zlevel is back active again.

Any movement towards a new zlevel will set it active.

The DORMANT state is purely to just not deactivate constantly the poor mindless mobs. The player might've just translated to another zlevel by chance, or they will come back mining in there, for instance. At most, a zlevel will be effectively inactive after 6 minutes of being idle. (Since the system checks every 3 minutes, and it needs two idle checks.)


NOTES (Pre-completion notes i took before making these changes, in case I have to look at em again):

zlevel data
	- add active var
	- spawn actual mobs
	- an activation proc
	Handles the active state of the zlevel. If zlevel is not active and this proc is called, it will immediately
	spawn monsters (in case there wasnt already) and activate the mob's AI (Life())
	- an on_save event trigger to force delete of ALL mob in order to prevent their saving
	(no use to save those bastards, just spawn em again after a restart load in case it is actually needed)
	this makes sure that no matter how man zlevels there are, we wont put too much delay on loading all those mobs
	at least

ssmaze
	- remove the replenish_monsters() proc from init so it doesnt straight up spawn mobs
	(we want to spawn mobs only if the zlevel is actually active.)
	- periodically check all PLAYER mobs to retrieve their zlevel locations
	After which we will set all zlevels that currently have no player on it DORMANT
	If the zlevel is already dormant, then it means it has been inactive for two checks already, thus setting it
	inactive and trigger all current monsters to freeze by stopping processing their AI
	which in turn cuts on processing power that is currently not being much of a use

On player mob zlevel translation
	- force zlevel activation