### PR TITLE
Fix welder runtimes + id tag saving

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -142,6 +142,7 @@ Class Procs:
 	ADD_SAVED_VAR(malf_upgraded)
 	ADD_SAVED_VAR(emagged)
 	ADD_SAVED_VAR(stat)
+	ADD_SAVED_VAR(id_tag)
 
 	ADD_SKIP_EMPTY(extensions)
 	ADD_SKIP_EMPTY(component_parts)

--- a/code/game/objects/items/weapons/tools/welders/industrial_welder.dm
+++ b/code/game/objects/items/weapons/tools/welders/industrial_welder.dm
@@ -15,7 +15,7 @@
 	welding_efficiency = 0.8
 
 /obj/item/weapon/tool/weldingtool/largetank/empty
-	tank = /obj/item/weapon/welder_tank/large/empty
+	tank = new /obj/item/weapon/welder_tank/large/empty
 
 //===================================
 //	Industrial welder tool tank

--- a/code/game/objects/items/weapons/tools/welders/mini_welder.dm
+++ b/code/game/objects/items/weapons/tools/welders/mini_welder.dm
@@ -12,7 +12,7 @@
 	welding_efficiency = 0.9
 
 /obj/item/weapon/tool/weldingtool/mini/empty
-	tank = /obj/item/weapon/welder_tank/mini/empty
+	tank = new /obj/item/weapon/welder_tank/mini/empty
 
 //===================================
 //	Mini welder tool tank

--- a/code/game/objects/items/weapons/tools/welders/upgraded_welder.dm
+++ b/code/game/objects/items/weapons/tools/welders/upgraded_welder.dm
@@ -16,7 +16,7 @@
 	welding_efficiency = 0.6
 
 /obj/item/weapon/tool/weldingtool/hugetank/empty
-	tank = /obj/item/weapon/welder_tank/huge/empty
+	tank = new /obj/item/weapon/welder_tank/huge/empty
 
 //===================================
 //	Upgraded welder tool tank


### PR DESCRIPTION
* Basically, empty welders still had a path instead of an instance as their tank when created, so I changed it for an instance. Should help a bunch.
* Also added the id_tag of machines to the saved vars. Its kind of a temporary fix though, since ideally, you'd want to query the radio extension for the tag, but I have some things to work out first.

<!-- 
!!IMPORTANT!!
Changes must be reviewed and approved by a developer before being merged.

If a developer has approved your PR, any other developer may immediately merge it, or the same developer may merge it after 24 hours.

A developer may not merge their own PR without the approval of two other developers.

Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
