### PR TITLE
Gen glob vars Python27 compatible

### DIFF
--- a/tools/GenerateGlobalVarAccess/gen_globals.py
+++ b/tools/GenerateGlobalVarAccess/gen_globals.py
@@ -27,6 +27,7 @@ import hashlib
 import os
 import sys
 import re
+import io
 from distutils import spawn
 try:
 	import subprocess32 as subprocess
@@ -52,7 +53,7 @@ def main():
 
 	else:
 		tree = CompileFile(namespace.projectfile)
-		with open("dump.txt", "wt", encoding='latin-1') as f:
+		with io.open("dump.txt", "wt", encoding='latin-1') as f:
 			f.write(tree)
 
 


### PR DESCRIPTION
Just a tiny little tweak so anyone who still lives in the past like me can use this :v 
Works on both major python versions. 