### PR TITLE
Some fixes and tweaks to the last changes regarding the APC

### DIFF
--- a/code/modules/factions/faction.dm
+++ b/code/modules/factions/faction.dm
@@ -1550,6 +1550,22 @@ var/PriorityQueue/all_feeds
 /datum/world_faction/proc/get_limits()
 	return limits
 
+//(Re)Calculates the current claimed area and returns it.
+/datum/world_faction/proc/get_claimed_area()
+	src.calculate_claimed_area()
+	return limits.claimed_area
+
+//Calculates the current claimed area. Only used by "get_claimed_area()" and "apc/can_disconnect()" procs.~
+//Call "get_claimed_area()" directly instead (in most cases).
+/datum/world_faction/proc/calculate_claimed_area()
+	var/new_claimed_area = 0
+
+	for(var/obj/machinery/power/apc/apc in limits.apcs)
+		if(!apc.area) continue
+		var/list/apc_turfs = get_area_turfs(apc.area)
+		new_claimed_area += apc_turfs.len
+	limits.claimed_area = new_claimed_area
+
 /datum/world_faction/proc/get_duty_status(var/real_name)
 	for(var/obj/item/organ/internal/stack/stack in connected_laces)
 		if(stack.get_owner_name() == real_name)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -144,32 +144,32 @@
 /obj/machinery/power/apc/can_connect(var/datum/world_faction/trying, var/mob/M)
 	if(!area)
 		return 0
-	var/list/turfs = get_area_turfs(area)
-	var/claimed_area = 0
 
+	var/list/turfs = get_area_turfs(area)
 	var/datum/machine_limits/limits = trying.get_limits()
+
 	if(M && !has_access(list(core_access_engineering_programs), list(), M.GetAccess(req_access_faction)))
 		to_chat(M, "You do not have access to link machines to [trying.name].")
 		return 0
-	for(var/obj/machinery/power/apc/apc in limits.apcs)
-		if(!apc.area) continue
-		var/list/apc_turfs = get_area_turfs(apc.area)
-		claimed_area += apc_turfs.len
 
-	if(limits.limit_area <= turfs.len + claimed_area)
+	if(limits.limit_area <= turfs.len + trying.get_claimed_area())
 		if(M)
 			to_chat(M, "[trying.name] cannot connect this APC as it will exceed its area limit.")
 		return 0
 	limits.apcs |= src
 	req_access_faction = trying.uid
-	connected_faction = src
+	connected_faction = trying
+	trying.calculate_claimed_area()
+	to_chat(M, "You successfuly connect this APC to [trying.name].")
 
 /obj/machinery/power/apc/can_disconnect(var/datum/world_faction/trying, var/mob/M)
 	var/datum/machine_limits/limits = trying.get_limits()
 	limits.apcs -= src
 	req_access_faction = ""
 	connected_faction = null
-	if(M) to_chat(M, "The machine has been disconnected.")
+	locked = 1
+	trying.calculate_claimed_area()
+	if(M) to_chat(M, "You successfuly disconnect this APC from [trying.name].")
 
 
 /obj/machinery/power/apc/connect_to_network()
@@ -558,18 +558,6 @@
 	else if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))			// trying to unlock the interface with an ID card
 		if(emagged)
 			to_chat(user, "The interface is broken.")
-		else if(!connected_faction)
-			var/obj/item/weapon/card/id/id
-			if(istype(W, /obj/item/weapon/card/id))
-				id = W
-			else if(istype(W, /obj/item/device/pda))
-				var/obj/item/device/pda/pda = W
-				id = pda.id
-			if(id)
-				var/datum/world_faction/faction = get_faction(id.selected_faction)
-				if(faction)
-					can_connect(faction, usr)
-					return
 		else if(opened)
 			to_chat(user, "You must close the cover to swipe an ID card.")
 		else if(wiresexposed)
@@ -582,6 +570,19 @@
 			if(src.allowed(usr) && !isWireCut(APC_WIRE_IDSCAN))
 				locked = !locked
 				to_chat(user, "You [ locked ? "lock" : "unlock"] the APC interface.")
+				if(!connected_faction && !locked)
+					var/obj/item/weapon/card/id/id
+					if(istype(W, /obj/item/weapon/card/id))
+						id = W
+					else if(istype(W, /obj/item/device/pda))
+						var/obj/item/device/pda/pda = W
+						id = pda.id
+					if(id)
+						var/datum/world_faction/faction = get_faction(id.selected_faction)
+						if(faction)
+							var/do_connect = input("Do you want to connect this APC to [faction.name] ?", faction.name, null) in list("Yes", "No") as text|null
+							if (do_connect == "Yes")
+								can_connect(faction, usr)
 				update_icon()
 			else
 				to_chat(user, "<span class='warning'>Access denied.</span>")

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -558,6 +558,17 @@
 	else if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))			// trying to unlock the interface with an ID card
 		if(emagged)
 			to_chat(user, "The interface is broken.")
+		else if(!connected_faction)
+			var/obj/item/weapon/card/id/id
+			if(istype(W, /obj/item/weapon/card/id))
+				id = W
+			else if(istype(W, /obj/item/device/pda))
+				var/obj/item/device/pda/pda = W
+				id = pda.id
+			if(id)
+				var/datum/world_faction/faction = get_faction(id.selected_faction)
+				if(faction)
+					can_connect(faction, usr)
 		else if(opened)
 			to_chat(user, "You must close the cover to swipe an ID card.")
 		else if(wiresexposed)
@@ -570,19 +581,6 @@
 			if(src.allowed(usr) && !isWireCut(APC_WIRE_IDSCAN))
 				locked = !locked
 				to_chat(user, "You [ locked ? "lock" : "unlock"] the APC interface.")
-				if(!connected_faction && !locked)
-					var/obj/item/weapon/card/id/id
-					if(istype(W, /obj/item/weapon/card/id))
-						id = W
-					else if(istype(W, /obj/item/device/pda))
-						var/obj/item/device/pda/pda = W
-						id = pda.id
-					if(id)
-						var/datum/world_faction/faction = get_faction(id.selected_faction)
-						if(faction)
-							var/do_connect = input("Do you want to connect this APC to [faction.name] ?", faction.name, null) in list("Yes", "No") as text|null
-							if (do_connect == "Yes")
-								can_connect(faction, usr)
 				update_icon()
 			else
 				to_chat(user, "<span class='warning'>Access denied.</span>")

--- a/nano/templates/apc.tmpl
+++ b/nano/templates/apc.tmpl
@@ -188,7 +188,7 @@
 				Alarm Status:
 			</div>
 			<div class="itemContent">
-				{{:helper.link('Armed', 'locked', {'arm' : 1}, data.alarm_status ? 'selected' : null)}}{{:helper.link('Disarmed', 'unlocked', {'disarm' : 1}, data.alarm_status ? 'selected' : null)}}
+				{{:helper.link('Armed', 'locked', {'arm' : 1}, data.alarm_status ? 'selected' : null)}}{{:helper.link('Disarmed', 'unlocked', {'disarm' : 1}, data.alarm_status ? null : 'selected')}}
 			</div>
 		</div>
 		<div class="item">
@@ -196,7 +196,7 @@
 				Required Access:
 			</div>
 			<div class="itemContent">
-				{{:helper.link(data.alarm_access, '', {'set_alarm' : 1}, null)}}
+				{{:helper.link(data.required, '', {'set_alarm' : 1}, null)}}
 			</div>
 		</div>
 		The access that is checked for everyone entering the area. If they dont have it, the alarm will trigger and after 5 seconds send alerts if the alarm hasn't been disabled.


### PR DESCRIPTION
Some fixes and tweaks to the last changes regarding the factions, apc and alarms.

 - faction.dm: calculate_claimed_area() and get_claimed_area() to make use of the claimed_area var in limits.
 - apc.dm: Fixed the APC.connected_faction referencing to the APC itself instead of the faction. Also tweaked along with the faction.dm changes, and now only when UNLOCKING it will ask if the player wants to connect the APC to their faction.
 - apc.tmpl: Arm/Disarm buttons were toggling wrongly which prevented from disarming the alarm. Also the access was displaying "undefined" since we were using data["alarm_access"] instead of the coded data["required"]. I opted going with the latter which was coded already, but the name should be changed.

<!-- 
!!IMPORTANT!!
Changes must be reviewed and approved by a developer before being merged.

If a developer has approved your PR, any other developer may immediately merge it, or the same developer may merge it after 24 hours.

A developer may not merge their own PR without the approval of two other developers.

Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
