### PR TITLE
Alarms v0.1 (WARNING: EXTREMELY LOUD & ANNOYING)

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -265,6 +265,9 @@ var/list/mob/living/forced_ambience_list = new
 	L.lastarea = newarea
 	play_ambience(L)
 
+	if(apc && apc.operating && !apc.shorted && !apc.failure_timer && !apc.stat & (BROKEN|MAINT))
+		apc.AlarmOnEntered(A)
+
 /area/proc/play_ambience(var/mob/living/M)
 	if(!M.client || M.get_preference_value(/datum/client_preference/play_ambience) == GLOB.PREF_NO || M.ear_deaf)
 		return 0

--- a/html/changelogs/ingles98-PR-1141.yml
+++ b/html/changelogs/ingles98-PR-1141.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Ingles98
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - wip: "Added Area detection Alarms - No e-mail nor security notification yet implemented."


### PR DESCRIPTION
Alarms now work on **Factionalized** APC's.

It has a warning mechanism which will trigger after 5 seconds if the previous potential threat is still in the area. The detection gets warned of this. Currently any amd all carbon/human are eligible for detection, player or non player alike.

Leaving the area before the timer will not trigger the alarm, but after the timer it will scan the entire area for threats, so there isnt much room for exploiting.

Ideally, with notifications, the alarm is so advanced it uses facial recognition on the threat, which will be reported. 

More detection procedures will be added soon, like door hacking and breaches.

We might wanna change the current sound as it doesn't loop well with the current tickrate of the APC heh.