### PR TITLE
Lace Storage and Dead Lace Teleportation

### DIFF
--- a/code/_global_vars/lists/objects.dm
+++ b/code/_global_vars/lists/objects.dm
@@ -12,6 +12,8 @@ GLOBAL_LIST_EMPTY(reg_dna)
 GLOBAL_LIST_EMPTY(global_map)
 
 GLOBAL_LIST_EMPTY(cryopods)
+GLOBAL_LIST_EMPTY(lace_storages)
+
 GLOBAL_LIST_EMPTY(frontierbeacons)
 GLOBAL_LIST_EMPTY(cargotelepads)
 

--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -8,10 +8,20 @@
 #define AB_CHECK_LYING 4
 #define AB_CHECK_ALIVE 8
 #define AB_CHECK_INSIDE 16
+
 /mob/living/carbon/lace/Life()
 	update_action_buttons()
+
 /datum/action/lace
 	name = "Access Lace UI"
+
+/datum/action/lace_storage
+	name = "Access Lace Storage UI"
+	action_type = AB_GENERIC
+	button_icon = 'icons/misc/lace.dmi'
+	button_icon_state = "lace"
+	procname = "lace_ui_interact"
+
 /datum/action
 	var/name = "Generic Action"
 	var/action_type = AB_ITEM
@@ -28,6 +38,7 @@
 
 	var/icon_override = null
 	var/override_state = ""
+
 /datum/action/New(var/Target)
 	target = Target
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -27,6 +27,7 @@
 	RefreshParts()
 
 /obj/machinery/cryopod/Destroy()
+	GLOB.cryopods -= src
 	for(var/atom/movable/A in InsertedContents())
 		A.forceMove(get_turf(src))
 	. = ..()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2,7 +2,7 @@
 
 var/list/preferences_datums = list()
 
-datum/preferences
+/datum/preferences
 	//doohickeys for savefiles
 	var/path
 	var/default_slot = 1				//Holder so it doesn't default to slot 1, rather the last one used

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -120,8 +120,6 @@
 		mannequin.equip_to_slot_or_del(backpack,slot_back)
 	mannequin.mind.initial_account = M
 	var/datum/computer_file/report/crew_record/record = CreateModularRecord(mannequin)
-	var/faction_uid = "refugee"
-	faction_uid = "nanotrasen"
 	var/datum/world_faction/factions = get_faction(faction)
 	if(factions)
 		var/datum/computer_file/report/crew_record/record2 = new()
@@ -142,7 +140,7 @@
 			stack.connected_faction = factions.uid
 			stack.try_connect()
 		mannequin.equip_to_slot_or_del(new /obj/item/device/radio/headset(mannequin),slot_l_ear)
-	mannequin.spawn_loc = faction_uid
+	mannequin.spawn_loc = faction
 	mannequin.spawn_type = 2
 	mannequin.species.equip_survival_gear(mannequin)
 	mannequin.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(mannequin),slot_shoes)

--- a/code/modules/factions/lace_storage.dm
+++ b/code/modules/factions/lace_storage.dm
@@ -1,0 +1,202 @@
+
+
+/obj/machinery/lace_storage
+	name = "Lace Storage"
+	desc = "Home to those who departed to their better selves."
+	anchored = 1
+	density = 1
+	icon = 'icons/obj/machines/dock_beacon.dmi'
+	icon_state = "unpowered2"
+	use_power = 0			//1 = idle, 2 = active
+	var/network = "default"
+
+/obj/machinery/lace_storage/New()
+	. = ..()
+	GLOB.lace_storages |= src
+
+
+/obj/machinery/lace_storage/before_save()
+	for (var/obj/item/organ/internal/stack/S in contents)
+		DespawnLace(S)
+	..()
+
+/obj/machinery/lace_storage/attackby(var/obj/item/O, var/mob/user = usr)
+
+	if (istype(O, /obj/item/weapon/card/id)||istype(O, /obj/item/device/pda))			// trying to unlock the interface with an ID card
+		if(!req_access_faction)
+			var/obj/item/weapon/card/id/id
+			if(istype(O, /obj/item/weapon/card/id))
+				id = O
+			else if(istype(O, /obj/item/device/pda))
+				var/obj/item/device/pda/pda = O
+				id = pda.id
+			if(id)
+				var/datum/world_faction/faction = get_faction(id.selected_faction)
+				if(faction)
+					req_access_faction = id.selected_faction
+					to_chat(user, SPAN_NOTICE("\The [src] has been connected to your organization.") )
+				else
+					to_chat(user, SPAN_WARNING("Access Denied.") )
+
+	if(!req_access_faction)
+		to_chat(user, "<span class='notice'>\The [src] hasn't been connected to a organization.</span>")
+		return
+	if(istype(O, /obj/item/organ/internal/stack))
+		InsertLace(O, user)
+		return
+
+/obj/machinery/lace_storage/interact(mob/user)
+	if (!user)
+		return
+	attack_hand(user)
+
+/obj/machinery/lace_storage/attack_hand(var/mob/user = usr)
+	if(stat)	// If there are any status flags, it shouldn't be opperable
+		return
+
+	user.set_machine(src)
+	src.add_fingerprint(user)
+
+	var/datum/world_faction/faction = get_faction(req_access_faction)
+
+	var/data[]
+	data += "<hr><br><b>Lace Storage Control</b></br>"
+	data += "This Lace Storage is [faction ? "connected to " + faction.name : "Not Connected"]<br><hr>"
+	if(faction)
+		data += "It's lace storage network is set to [network]<br><br>"
+		data += "<a href='?src=\ref[src];enter=1'>Enter Pod</a><br>"
+		data += "<a href='?src=\ref[src];eject=1'>Eject Occupant</a><br><br>"
+		data += "Those authorized can <a href='?src=\ref[src];disconnect=1'>disconnect this pod from the logistics network</a> or <a href='?src=\ref[src];connect_net=1'>connect to a different cryonetwork</a>."
+	else
+		data += "Those authorized can connect this lace storage using an ID on it.</a>"
+
+	show_browser(user, data, "window=cryopod")
+	onclose(user, "cryopod")
+
+/obj/machinery/lace_storage/OnTopic(var/mob/user = usr, href_list)
+	if(href_list["eject"])
+		EjectLaces()
+	if(href_list["disconnect"])
+		if(allowed(user) && req_access_faction)
+			var/datum/world_faction/faction = get_faction(req_access_faction)
+			req_access_faction = ""
+			to_chat(user, SPAN_NOTICE("\The [src] has been disconnected from [faction? faction.name : "ERROR" ] .") )
+		else
+			to_chat(user, SPAN_WARNING("Access Denied.") )
+
+/obj/machinery/lace_storage/ui_action_click()
+	attack_hand(usr)
+
+/obj/machinery/lace_storage/Process()
+	if (!use_power || stat)
+		return
+
+	for (var/obj/item/organ/internal/stack/S in contents)
+		var/mob/living/carbon/lace/mob = S.lacemob
+		if (!mob || !istype(mob))
+			qdel(S)
+			continue
+		if (!mob.client)
+			DespawnLace(S)
+			continue
+		/*if (!mob.storage_action)
+			mob.storage_action = new(src)
+			mob.storage_action.Grant(mob)
+			mob.update_action_buttons()*/
+
+/obj/machinery/lace_storage/proc/InsertLace(var/obj/item/organ/internal/stack/S, var/mob/user)
+	if (!S)
+		return
+	if(!S.lacemob)
+		to_chat(user, "<span class='notice'>\The [S] is inert.</span>")
+		return
+	user.drop_from_inventory(S)
+	S.forceMove(src)
+	to_chat(user, SPAN_NOTICE("You insert \the [S] into \the [src]."))
+
+/obj/machinery/lace_storage/proc/DespawnLace(var/obj/item/organ/internal/stack/S)
+	if(!S)
+		return 0
+
+	if (!S.lacemob)
+		qdel(S)
+		return
+
+	var/mob/new_player/player = new(locate(100,100,51))
+	var/mob/character
+	var/key
+	var/name = ""
+	var/dir = 0
+
+	if(S.lacemob.ckey)
+		S.lacemob.stored_ckey = S.lacemob.ckey
+		key = S.lacemob.ckey
+		player.ckey = S.lacemob.ckey
+	else
+		key = S.lacemob.stored_ckey
+		player.ckey = S.lacemob.stored_ckey
+	name = S.get_owner_name()
+	character = S.lacemob
+	dir = S.lacemob.save_slot
+	S.lacemob.spawn_loc = req_access_faction
+	S.lacemob.spawn_loc_2 = network
+	S.lacemob.spawn_type = 1
+	S.loc = null
+
+	//
+
+	key = copytext(key, max(findtext(key, "@"), 1))
+
+	if(!dir)
+		log_and_message_admins("Warning! [key]'s [S] failed to find a save_slot, and is picking one!")
+		for(var/file in flist(load_path(key, "")))
+			var/firstNumber = text2num(copytext(file, 1, 2))
+			if(firstNumber)
+				var/storedName = CharacterName(firstNumber, key)
+				if(storedName == name)
+					dir = firstNumber
+					log_and_message_admins("[key]'s [S] found a savefile with it's realname [file]")
+					break
+		if(!dir)
+			dir++
+			while(fexists(load_path(key, "[dir].sav")))
+				dir++
+
+
+	var/savefile/F = new(load_path(key, "[dir].sav"))
+	to_file(F["name"], name)
+	to_file(F["mob"], character)
+	if(req_access_faction == "betaquad")
+		var/savefile/E = new(beta_path(key, "[dir].sav"))
+		to_file(E["name"], name)
+		to_file(E["mob"], character)
+		to_file(E["records"], Retrieve_Record(name))
+	if(req_access_faction == "exiting")
+		var/savefile/E = new(beta_path(key, "[dir].sav"))
+		to_file(E["name"], name)
+		to_file(E["mob"], character)
+		to_file(E["records"], Retrieve_Record(name))
+
+	src.name = initial(src.name)
+	icon_state = initial(icon_state)
+	S.loc = null
+	QDEL_NULL(S)
+
+/obj/machinery/lace_storage/proc/EjectLaces()
+	var/list/laces = new()
+	for (var/obj/item/organ/internal/stack/S in contents)
+		laces |= S
+
+	var/obj/item/organ/internal/stack/ejecting = input("Choose a Lace to eject from \The [src]", "[src]") in laces
+	if (ejecting)
+		EjectLace(ejecting)
+
+/obj/machinery/lace_storage/proc/EjectLace(var/obj/item/organ/internal/stack/ejecting)
+	if (! ejecting in contents)
+		return
+	ejecting.loc = get_turf(src)
+	/*if (ejecting.lacemob.storage_action)
+		ejecting.lacemob.storage_action.Remove()
+		ejecting.lacemob.storage_action = null
+	ejecting.lacemob.update_action_buttons()
+	*/

--- a/code/modules/mob/living/carbon/lace/lace.dm
+++ b/code/modules/mob/living/carbon/lace/lace.dm
@@ -13,6 +13,8 @@
 
 	var/teleport_time = 0 // time when you can teleport back to nexus
 
+	var/datum/action/lace_storage/tmp_storage_action
+
 /mob/living/carbon/lace/New()
 	container = loc
 	var/datum/action/lace/laceaction = new(container)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -241,13 +241,7 @@
 			character.spawn_loc_2 = " default"
 
 		if (istype(character, /mob/living/carbon/lace) )
-			for(var/obj/machinery/lace_storage/S in GLOB.lace_storages)
-				if(S.req_access_faction == character.spawn_loc)
-					if(S.network == character.spawn_loc_2)
-						spawnTurf = S
-						break
-					else
-						spawnTurf = S
+			spawnTurf = GetLaceStorage(character)
 
 		if (!spawnTurf)
 			for(var/obj/machinery/cryopod/pod in GLOB.cryopods)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -240,18 +240,28 @@
 			// The character doesn't have a spawn_loc_2, so use the one for their assignment or the default
 			character.spawn_loc_2 = " default"
 
-		for(var/obj/machinery/cryopod/pod in GLOB.cryopods)
-			if(!pod.loc)
-				qdel(pod)
-				continue
-			if(pod.req_access_faction == character.spawn_loc)
-				if(pod.network == character.spawn_loc_2)
+		if (istype(character, /mob/living/carbon/lace) )
+			for(var/obj/machinery/lace_storage/S in GLOB.lace_storages)
+				if(S.req_access_faction == character.spawn_loc)
+					if(S.network == character.spawn_loc_2)
+						spawnTurf = S
+						break
+					else
+						spawnTurf = S
+
+		if (!spawnTurf)
+			for(var/obj/machinery/cryopod/pod in GLOB.cryopods)
+				if(!pod.loc)
+					qdel(pod)
+					continue
+				if(pod.req_access_faction == character.spawn_loc)
+					if(pod.network == character.spawn_loc_2)
+						spawnTurf = get_turf(pod)
+						break
+					else
+						spawnTurf = get_turf(pod)
+				else if(!spawnTurf)
 					spawnTurf = get_turf(pod)
-					break
-				else
-					spawnTurf = get_turf(pod)
-			else if(!spawnTurf)
-				spawnTurf = get_turf(pod)
 
 		if(!spawnTurf)
 			log_and_message_admins("WARNING! No cryopods avalible for spawning! Get some spawned and connected to the starting factions uid (req_access_faction)")
@@ -280,6 +290,7 @@
 		log_and_message_admins("WARNING! Unable To Find Any Spawn Turf!!! Prehaps you didn't include a map?")
 		return
 
+	character.forceMove(spawnTurf)
 	character.after_spawn()
 
 	if(!character.mind)		// Not entirely sure what this if() block does, but keeping it just in case
@@ -289,7 +300,6 @@
 			mind.store_memory(client.prefs.memory)
 			mind.transfer_to(character)
 
-	character.forceMove(spawnTurf)
 	character.stored_ckey = key
 	character.key = key
 	character.save_slot = chosen_slot

--- a/code/modules/organs/internal/stack.dm
+++ b/code/modules/organs/internal/stack.dm
@@ -1,3 +1,6 @@
+// How long should dead lace mobs wait before being able to teleport ?
+#define DEAD_LACEMOB_STORAGE_TELEPORT_DELAY	120 MINUTES
+
 GLOBAL_LIST_EMPTY(neural_laces)
 /mob/var/perma_dead = 0
 
@@ -85,7 +88,7 @@ GLOBAL_LIST_EMPTY(neural_laces)
 	lacemob.real_name = H.real_name
 	lacemob.dna = H.dna.Clone()
 	lacemob.timeofhostdeath = H.timeofdeath
-	lacemob.teleport_time = H.timeofdeath + 30 MINUTES
+	lacemob.teleport_time = H.timeofdeath + DEAD_LACEMOB_STORAGE_TELEPORT_DELAY
 	lacemob.container = src
 	if(owner && isnull(owner.gc_destroyed))
 		lacemob.container2 = owner
@@ -171,14 +174,13 @@ GLOBAL_LIST_EMPTY(neural_laces)
 		if("select_ballot")
 			selected_ballot = locate(href_list["ref"])
 
-		if("teleport") // NEEDS TO BE DONE
-			var/mob/living/carbon/lace/mob = usr
-			var/obj/machinery/lace_storage/storage = GetLaceStorage(mob)
+		if("teleport")
+			var/obj/machinery/lace_storage/storage = GetLaceStorage(lacemob)
 			if (storage)
-				mob.container.forceMove(storage)
+				forceMove(storage)
 				return 1
 			else
-				message_admins("Couldnt find a Lace Storage for lacemob [mob] (stack.dm)")
+				message_admins("Couldnt find a Lace Storage for lacemob [lacemob] (stack.dm)")
 			return 0
 
 	if(href_list["page_up"])

--- a/code/modules/organs/internal/stack.dm
+++ b/code/modules/organs/internal/stack.dm
@@ -85,7 +85,7 @@ GLOBAL_LIST_EMPTY(neural_laces)
 	lacemob.real_name = H.real_name
 	lacemob.dna = H.dna.Clone()
 	lacemob.timeofhostdeath = H.timeofdeath
-	lacemob.teleport_time = H.timeofdeath + 30 MINUTES
+	lacemob.teleport_time = H.timeofdeath + 15 SECONDS//30 MINUTES //TESTING!!!!
 	lacemob.container = src
 	if(owner && isnull(owner.gc_destroyed))
 		lacemob.container2 = owner
@@ -172,7 +172,14 @@ GLOBAL_LIST_EMPTY(neural_laces)
 			selected_ballot = locate(href_list["ref"])
 
 		if("teleport") // NEEDS TO BE DONE
-			return 1
+			var/mob/living/carbon/lace/mob = usr
+			var/obj/machinery/lace_storage/storage = GetLaceStorage(mob)
+			if (storage)
+				mob.container.forceMove(storage)
+				return 1
+			else
+				message_admins("Couldnt find a Lace Storage for lacemob [mob] (stack.dm)")
+			return 0
 
 	if(href_list["page_up"])
 		curr_page++

--- a/code/modules/organs/internal/stack.dm
+++ b/code/modules/organs/internal/stack.dm
@@ -85,7 +85,7 @@ GLOBAL_LIST_EMPTY(neural_laces)
 	lacemob.real_name = H.real_name
 	lacemob.dna = H.dna.Clone()
 	lacemob.timeofhostdeath = H.timeofdeath
-	lacemob.teleport_time = H.timeofdeath + 15 SECONDS//30 MINUTES //TESTING!!!!
+	lacemob.teleport_time = H.timeofdeath + 30 MINUTES
 	lacemob.container = src
 	if(owner && isnull(owner.gc_destroyed))
 		lacemob.container2 = owner

--- a/nano/templates/lace_storage.tmpl
+++ b/nano/templates/lace_storage.tmpl
@@ -1,0 +1,34 @@
+<h2>Lace Storage Control Panel</h2>
+<br><hr>
+{{if data.living}}
+	{{if data.faction}}
+		<h3>This Lace Storage unit is connected to {{:data.faction}}.</h3><br>
+		<div class='itemLabel'>
+			{{:helper.link("Disconnect", '', {'action' : 'disconnect'},  null)}}
+		</div>
+	{{/if}}
+	<div class='itemLabel'>
+		{{:helper.link("Eject Lace", '', {'action' : 'eject_lace'},  null)}}
+	</div>
+{{else}}
+	<h3>Death Controls</h3><br>
+	Your conciousness burns inside this mechanical prison. You review your options.<br>
+	<div class='item'>
+		<div class='itemLabel'>
+			{{:helper.link("Rest Mind", '', {'action' : 'despawn'},  null)}}
+		</div>
+		<div class='itemContent'>
+			Not only the body that once was yours gets tired, your mind does too. Get your mind to rest.<br>
+			OOC Note: This allows you to go back to the Character Selection screen. Meanwhile, your lace won't be visible within this machine.
+		</div>
+	</div>
+	<div class='item'>
+		<div class='itemLabel'>
+			{{:helper.link("Ping Insurance", '', {'action' : 'ping_insurance'}, data.can_insurance ? null : 'disabled')}}
+		</div>
+		<div class='itemContent'>
+			Ping your insurance company of the position of your lace, so that you get replaced onto a body as soon as possible!
+		</div>
+	</div>
+	
+{{/if}}

--- a/nano/templates/lace_storage.tmpl
+++ b/nano/templates/lace_storage.tmpl
@@ -1,16 +1,27 @@
 <h2>Lace Storage Control Panel</h2>
 <br><hr>
+
 {{if data.living}}
+
 	{{if data.faction}}
 		<h3>This Lace Storage unit is connected to {{:data.faction}}.</h3><br>
-		<div class='itemLabel'>
-			{{:helper.link("Disconnect", '', {'action' : 'disconnect'},  null)}}
+		<div class='item'>
+			<div class='itemLabel'>
+				{{:helper.link("Disconnect", '', {'action' : 'disconnect'},  null)}}
+			</div>
+		</div>
+		<div class='item'>
+			<div class='itemLabel'>
+				{{:helper.link("Eject a Lace", '', {'action' : 'eject_lace'},  null)}}
+			</div>
+			<div class='itemContent'>
+				You'll be prompted to choose a lace to pick up.
+			</div>
 		</div>
 	{{/if}}
-	<div class='itemLabel'>
-		{{:helper.link("Eject Lace", '', {'action' : 'eject_lace'},  null)}}
-	</div>
+
 {{else}}
+
 	<h3>Death Controls</h3><br>
 	Your conciousness burns inside this mechanical prison. You review your options.<br>
 	<div class='item'>
@@ -24,7 +35,7 @@
 	</div>
 	<div class='item'>
 		<div class='itemLabel'>
-			{{:helper.link("Ping Insurance", '', {'action' : 'ping_insurance'}, data.can_insurance ? null : 'disabled')}}
+			{{:helper.link("Ping Insurance", '', {'action' : 'ping_insurance'}, data.has_insurance ? null : 'disabled')}}
 		</div>
 		<div class='itemContent'>
 			Ping your insurance company of the position of your lace, so that you get replaced onto a body as soon as possible!

--- a/persistentss13.dme
+++ b/persistentss13.dme
@@ -1533,6 +1533,7 @@
 #include "code\modules\factions\bluespace_satellite.dm"
 #include "code\modules\factions\faction.dm"
 #include "code\modules\factions\frontier_beacon.dm"
+#include "code\modules\factions\lace_storage.dm"
 #include "code\modules\flufftext\Dreaming.dm"
 #include "code\modules\flufftext\TextFilters.dm"
 #include "code\modules\food\recipes_microwave.dm"


### PR DESCRIPTION
**Adds a Lace Storage and the ability for dead lace mobs to teleport to them.**

The Lace UI already had a teleport button made by brawler, with a 30 **(EDIT: 120)** minute delay after death. This PR adds in the ability to use it. 

Laces can despawn at Lace Storage the same way you could on a cryo as a living mob, giving you the ability to play other character while your pretty much a ded being.

Living mobs can interact with the machine to eject or input dead laces into them, mostly for replacing them at a later date, or to throw you into space idk. 

Disconnecting while inside the machine will despawn you from it automatically, **if the machine is operating**. 

Only connected lace characters will be seen by the living mobs interacting with it, so you cannot be ejected from the machine while you are offline.

**Important Notes**
 - The machine will only work while it has power. 
 - For now, it shall only be admin spawned and non-deconstructable. 
 - The machine will actively delete inert permadead laces, or laces that dont have a mob attached. If anything goes wrong with laces getting deleted when they shouldnt, this is where to look at first.
 - **The machine is fairly breakable through explosion and perhaps fire.**

**TO-DO**
 - Machine and Action sprites.