### PR TITLE
make sleepers and dispensers able to accept reagent cartridges again

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -405,12 +405,12 @@
 			to_chat(user, "<span class='warning'>\The [src] does not have any slots open for \the [C] to fit into!</span>")
 		return
 
-	if(!C.label_text)
+	if(!C.get_first_label())
 		if(user)
 			to_chat(user, "<span class='warning'>\The [C] does not have a label!</span>")
 		return
 
-	if(cartridges[C.label_text])
+	if(cartridges[C.get_first_label()])
 		if(user)
 			to_chat(user, "<span class='warning'>\The [src] already contains a cartridge with that label!</span>")
 		return
@@ -420,7 +420,7 @@
 		to_chat(user, "<span class='notice'>You add \the [C] to \the [src].</span>")
 
 	C.loc = src
-	cartridges[C.label_text] = C
+	cartridges[C.get_first_label()] = C
 	cartridges = sortAssoc(cartridges)
 	SSnano.update_uis(src)
 

--- a/code/modules/reagents/dispenser/cartridge.dm
+++ b/code/modules/reagents/dispenser/cartridge.dm
@@ -2,9 +2,7 @@
 	name = "chemical dispenser cartridge"
 	desc = "This goes in a chemical dispenser."
 	icon_state = "cartridge"
-
 	w_class = ITEM_SIZE_NORMAL
-
 	volume = CARTRIDGE_VOLUME_LARGE
 	amount_per_transfer_from_this = 50
 	// Large, but inaccurate. Use a chem dispenser or beaker for accuracy.
@@ -12,18 +10,13 @@
 	unacidable = 1
 	matter = list(MATERIAL_STEEL = 100) //Not made from steel buuut we need a way to recycle them
 	var/spawn_reagent = null
-	var/label = ""
-
-/obj/item/weapon/reagent_containers/chem_disp_cartridge/New()
-	. = ..()
-	ADD_SAVED_VAR(label)
 
 /obj/item/weapon/reagent_containers/chem_disp_cartridge/SetupReagents()
 	. = ..()
 	if(spawn_reagent)
 		reagents.add_reagent(spawn_reagent, volume)
 		var/datum/reagent/R = spawn_reagent
-		setLabel(initial(R.name))
+		set_label(null, initial(R.name))
 
 /obj/item/weapon/reagent_containers/chem_disp_cartridge/examine(mob/user)
 	. = ..()
@@ -40,20 +33,21 @@
 	set category = "Object"
 	set src in view(usr, 1)
 
-	setLabel(L, usr)
+	set_label(usr, L)
 
-/obj/item/weapon/reagent_containers/chem_disp_cartridge/proc/setLabel(L, mob/user = null)
-	if(L)
-		if(user)
-			to_chat(user, "<span class='notice'>You set the label on \the [src] to '[L]'.</span>")
+// /obj/item/weapon/reagent_containers/chem_disp_cartridge/proc/setLabel(L, mob/user = null)
+// 	set_label(user, L)
+// 	// if(L)
+// 	// 	if(user)
+// 	// 		to_chat(user, "<span class='notice'>You set the label on \the [src] to '[L]'.</span>")
 
-		label = L
-		SetName("[initial(name)] - '[L]'")
-	else
-		if(user)
-			to_chat(user, "<span class='notice'>You clear the label on \the [src].</span>")
-		label = ""
-		SetName(initial(name))
+// 	// 	label = L
+// 	// 	SetName("[initial(name)] - '[L]'")
+// 	// else
+// 	// 	if(user)
+// 	// 		to_chat(user, "<span class='notice'>You clear the label on \the [src].</span>")
+// 	// 	label = ""
+// 	// 	SetName(initial(name))
 
 /obj/item/weapon/reagent_containers/chem_disp_cartridge/attack_self()
 	..()

--- a/code/modules/reagents/dispenser/cartridge_spawn.dm
+++ b/code/modules/reagents/dispenser/cartridge_spawn.dm
@@ -9,5 +9,5 @@
 		if("large") C = new /obj/item/weapon/reagent_containers/chem_disp_cartridge(usr.loc)
 	C.reagents.add_reagent(reagent, C.volume)
 	var/datum/reagent/R = reagent
-	C.setLabel(initial(R.name))
+	C.set_label(null, initial(R.name))
 	log_and_message_admins("spawned a [size] reagent container containing [reagent]")

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -45,12 +45,13 @@
 			to_chat(user, "<span class='warning'>\The [src] does not have any slots open for \the [C] to fit into!</span>")
 		return
 
-	if(!C.label)
+	var/lbl = C.get_first_label()
+	if(!lbl)
 		if(user)
 			to_chat(user, "<span class='warning'>\The [C] does not have a label!</span>")
 		return
 
-	if(cartridges[C.label])
+	if(cartridges[lbl])
 		if(user)
 			to_chat(user, "<span class='warning'>\The [src] already contains a cartridge with that label!</span>")
 		return
@@ -62,7 +63,7 @@
 			return
 
 	C.forceMove(src)
-	cartridges[C.label] = C
+	cartridges[lbl] = C
 	cartridges = sortAssoc(cartridges)
 	SSnano.update_uis(src)
 

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -29,23 +29,24 @@
 		/datum/reagent/nutriment/vinegar = /obj/item/weapon/reagent_containers/food/condiment/vinegar
 		)
 
-/obj/item/weapon/reagent_containers/food/condiment/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
-	if(istype(W, /obj/item/weapon/pen) || istype(W, /obj/item/device/flashlight/pen))
-		var/tmp_label = sanitizeSafe(input(user, "Enter a label for [name]", "Label", label_text), MAX_NAME_LEN)
-		if(tmp_label == label_text)
-			return
-		if(length(tmp_label) > 10)
-			to_chat(user, "<span class='notice'>The label can be at most 10 characters long.</span>")
-		else
-			if(length(tmp_label))
-				to_chat(user, "<span class='notice'>You set the label to \"[tmp_label]\".</span>")
-				label_text = tmp_label
-				name = addtext(name," ([label_text])")
-			else
-				to_chat(user, "<span class='notice'>You remove the label.</span>")
-				label_text = null
-				on_reagent_change()
-		return
+//Handled in base class
+// /obj/item/weapon/reagent_containers/food/condiment/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
+// 	if(istype(W, /obj/item/weapon/pen) || istype(W, /obj/item/device/flashlight/pen))
+// 		var/tmp_label = sanitizeSafe(input(user, "Enter a label for [name]", "Label", label), MAX_NAME_LEN)
+// 		if(tmp_label == label)
+// 			return
+// 		if(length(tmp_label) > 10)
+// 			to_chat(user, "<span class='notice'>The label can be at most 10 characters long.</span>")
+// 		else
+// 			if(length(tmp_label))
+// 				to_chat(user, "<span class='notice'>You set the label to \"[tmp_label]\".</span>")
+// 				label = tmp_label
+// 				name = addtext(name," ([label])")
+// 			else
+// 				to_chat(user, "<span class='notice'>You remove the label.</span>")
+// 				label = null
+// 				on_reagent_change()
+// 		return
 
 
 
@@ -101,8 +102,9 @@
 			icon_state = "mixedcondiments"
 		else
 			icon_state = "emptycondiment"
-	if(label_text)
-		name = addtext(name," ([label_text])")
+	//Handled by label extension via events
+	// if(label)
+	// 	name = addtext(name," ([label])")
 
 /obj/item/weapon/reagent_containers/food/condiment/enzyme
 	name = "universal enzyme"


### PR DESCRIPTION
* Since there were like 3 different ways to label things it kinda messed up the sleeper and reagent dispenser that relied on a particular way which wasn't used much or obvious. So I made them use the newly made label extension, which most things use now.

