### PR TITLE
Removes duplicate device cell entry

### DIFF
--- a/code/modules/research/fabricators/engineering_fabricator.dm
+++ b/code/modules/research/fabricators/engineering_fabricator.dm
@@ -544,11 +544,6 @@
 // STOCK PARTS //
 
 
-/datum/design/item/engifab/parts/cell_device
-	name = "Device cell"
-	build_path = /obj/item/weapon/cell/device/standard/empty
-	materials = list(MATERIAL_STEEL = 1 SHEET, MATERIAL_GLASS = 1 SHEET)
-
 /datum/design/item/engifab/parts/basic_capacitor
 	name = "Basic capacitor"
 	materials = list(MATERIAL_STEEL = 1 SHEET, MATERIAL_GLASS = 1 SHEET)


### PR DESCRIPTION
There were two entries for a 25w device power cell, one of which costs significantly more and printed with zero charge. This removes it from the fabs list.

<!-- 
!!IMPORTANT!!
Changes must be reviewed and approved by a developer before being merged.

If a developer has approved your PR, any other developer may immediately merge it, or the same developer may merge it after 24 hours.

A developer may not merge their own PR without the approval of two other developers.

Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
