### PR TITLE
Removal of Gyrojet Weaponry

### DIFF
--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -167,7 +167,7 @@
 //--------------------------------
 //	Gyrojet Rounds
 //--------------------------------
-///obj/item/ammo_casing/gyrojet
+//obj/item/ammo_casing/gyrojet
 //	desc = "A gyrojet bullet casing."
 //	caliber = CALIBER_GYROJET
 //	projectile_type = /obj/item/projectile/bullet/gyro

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -167,13 +167,13 @@
 //--------------------------------
 //	Gyrojet Rounds
 //--------------------------------
-/obj/item/ammo_casing/gyrojet
-	desc = "A gyrojet bullet casing."
-	caliber = CALIBER_GYROJET
-	projectile_type = /obj/item/projectile/bullet/gyro
-	icon_state = "gyro-casing"
-	spent_icon = "gyro-casing" //Its a single piece rocket, there's no spent casing
-	matter = list(MATERIAL_STEEL = 520, /datum/reagent/aluminum = 30)
+///obj/item/ammo_casing/gyrojet
+//	desc = "A gyrojet bullet casing."
+//	caliber = CALIBER_GYROJET
+//	projectile_type = /obj/item/projectile/bullet/gyro
+//	icon_state = "gyro-casing"
+//	spent_icon = "gyro-casing" //Its a single piece rocket, there's no spent casing
+//	matter = list(MATERIAL_STEEL = 520, /datum/reagent/aluminum = 30)
 
 //--------------------------------
 //	4mm Flechettes Rounds

--- a/code/modules/projectiles/guns/projectile/pistols/gyrojet.dm
+++ b/code/modules/projectiles/guns/projectile/pistols/gyrojet.dm
@@ -1,42 +1,42 @@
 //
 //
 //
-/obj/item/weapon/gun/projectile/pistol/gyropistol
-	name = "gyrojet pistol"
-	desc = "A bulky pistol designed to fire self propelled rounds."
-	icon = 'icons/obj/weapons/guns/gyropistol.dmi'
-	icon_state = "gyropistol"
-	max_shells = 8
-	caliber = CALIBER_GYROJET
-	origin_tech = list(TECH_COMBAT = 3)
-	magazine_type = /obj/item/ammo_magazine/box/gyrojet
-	allowed_magazines = /obj/item/ammo_magazine/box/gyrojet
-	handle_casings = CLEAR_CASINGS	//the projectile is the casing
-	fire_delay = 25
-	auto_eject = 1
-	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
-	mag_insert_sound = 'sound/weapons/guns/interaction/hpistol_magin.ogg'
-	mag_remove_sound = 'sound/weapons/guns/interaction/hpistol_magout.ogg'
-	empty_icon = FALSE
-	mass = 0.625
+///obj/item/weapon/gun/projectile/pistol/gyropistol
+//	name = "gyrojet pistol"
+//	desc = "A bulky pistol designed to fire self propelled rounds."
+//	icon = 'icons/obj/weapons/guns/gyropistol.dmi'
+//	icon_state = "gyropistol"
+//	max_shells = 8
+//	caliber = CALIBER_GYROJET
+//	origin_tech = list(TECH_COMBAT = 3)
+//	magazine_type = /obj/item/ammo_magazine/box/gyrojet
+//	allowed_magazines = /obj/item/ammo_magazine/box/gyrojet
+//	handle_casings = CLEAR_CASINGS	//the projectile is the casing
+//	fire_delay = 25
+//	auto_eject = 1
+//	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
+//	mag_insert_sound = 'sound/weapons/guns/interaction/hpistol_magin.ogg'
+//	mag_remove_sound = 'sound/weapons/guns/interaction/hpistol_magout.ogg'
+//	empty_icon = FALSE
+//	mass = 0.625
 
-/obj/item/weapon/gun/projectile/pistol/gyropistol/on_update_icon()
-	..()
-	if(ammo_magazine)
-		icon_state = "gyropistolloaded"
-	else
-		icon_state = "gyropistol"
+///obj/item/weapon/gun/projectile/pistol/gyropistol/on_update_icon()
+//	..()
+//	if(ammo_magazine)
+//		icon_state = "gyropistolloaded"
+//	else
+//		icon_state = "gyropistol"
 
 //
 //	Gyrojet Magazine
 //
-/obj/item/ammo_magazine/box/gyrojet
-	name = "gyeojet pistol magazine"
-	icon_state = "gyrojet"
-	mag_type = MAGAZINE
-	caliber = CALIBER_GYROJET
-	ammo_type = /obj/item/ammo_casing/gyrojet
-	multiple_sprites = 1
-	max_ammo = 6
-/obj/item/ammo_magazine/box/gyrojet/empty
-	initial_ammo = 0
+///obj/item/ammo_magazine/box/gyrojet
+//	name = "gyeojet pistol magazine"
+//	icon_state = "gyrojet"
+//	mag_type = MAGAZINE
+//	caliber = CALIBER_GYROJET
+//	ammo_type = /obj/item/ammo_casing/gyrojet
+//	multiple_sprites = 1
+//	max_ammo = 6
+///obj/item/ammo_magazine/box/gyrojet/empty
+//	initial_ammo = 0

--- a/code/modules/projectiles/guns/projectile/pistols/gyrojet.dm
+++ b/code/modules/projectiles/guns/projectile/pistols/gyrojet.dm
@@ -1,7 +1,7 @@
 //
 //
 //
-///obj/item/weapon/gun/projectile/pistol/gyropistol
+//obj/item/weapon/gun/projectile/pistol/gyropistol
 //	name = "gyrojet pistol"
 //	desc = "A bulky pistol designed to fire self propelled rounds."
 //	icon = 'icons/obj/weapons/guns/gyropistol.dmi'
@@ -20,7 +20,7 @@
 //	empty_icon = FALSE
 //	mass = 0.625
 
-///obj/item/weapon/gun/projectile/pistol/gyropistol/on_update_icon()
+//obj/item/weapon/gun/projectile/pistol/gyropistol/on_update_icon()
 //	..()
 //	if(ammo_magazine)
 //		icon_state = "gyropistolloaded"
@@ -30,7 +30,7 @@
 //
 //	Gyrojet Magazine
 //
-///obj/item/ammo_magazine/box/gyrojet
+//obj/item/ammo_magazine/box/gyrojet
 //	name = "gyeojet pistol magazine"
 //	icon_state = "gyrojet"
 //	mag_type = MAGAZINE

--- a/code/modules/projectiles/guns/projectile/pistols/gyrojet.dm
+++ b/code/modules/projectiles/guns/projectile/pistols/gyrojet.dm
@@ -38,5 +38,5 @@
 //	ammo_type = /obj/item/ammo_casing/gyrojet
 //	multiple_sprites = 1
 //	max_ammo = 6
-///obj/item/ammo_magazine/box/gyrojet/empty
+//obj/item/ammo_magazine/box/gyrojet/empty
 //	initial_ammo = 0

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -389,13 +389,13 @@
 //---------------------------------------------------
 //	Gyrojet Rocket
 //---------------------------------------------------
-/obj/item/projectile/bullet/gyro
-	force = 25
-	penetrating = 1
-	armor_penetration = 10
-	penetration_modifier = 1.5
-	distance_falloff = 0.5
-	mass = 0.012
+///obj/item/projectile/bullet/gyro
+//	force = 25
+//	penetrating = 1
+//	armor_penetration = 10
+//	penetration_modifier = 1.5
+//	distance_falloff = 0.5
+//	mass = 0.012
 
 //Gyrojet rounds don't explode.. They're meant to deal kinectic damage
 ///obj/item/projectile/bullet/gyro/on_hit(var/atom/target, var/blocked = 0)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -389,7 +389,7 @@
 //---------------------------------------------------
 //	Gyrojet Rocket
 //---------------------------------------------------
-///obj/item/projectile/bullet/gyro
+//obj/item/projectile/bullet/gyro
 //	force = 25
 //	penetrating = 1
 //	armor_penetration = 10
@@ -398,7 +398,7 @@
 //	mass = 0.012
 
 //Gyrojet rounds don't explode.. They're meant to deal kinectic damage
-///obj/item/projectile/bullet/gyro/on_hit(var/atom/target, var/blocked = 0)
+//obj/item/projectile/bullet/gyro/on_hit(var/atom/target, var/blocked = 0)
 	// if(isturf(target))
 	// 	explosion(target, -1, 0, 2)
 	//..()

--- a/code/modules/research/fabricators/weapons_fabricator.dm
+++ b/code/modules/research/fabricators/weapons_fabricator.dm
@@ -346,11 +346,6 @@
 	build_path = /obj/item/weapon/gun/projectile/pistol/usp
 	research = "pistol_2"
 
-/datum/design/item/weaponfab/weapons/guns/pistol/gyrojet // tier 3, but its not very good
-	materials = list(MATERIAL_STEEL = 3 SHEETS, MATERIAL_GOLD = 1.3 SHEETS, MATERIAL_COPPER = 1.3 SHEETS) //TODO
-	build_path = /obj/item/weapon/gun/projectile/pistol/gyropistol
-	research = "pistol_2"
-
 /datum/design/item/weaponfab/weapons/guns/pistol/magnum_pistol // tier 4
 	materials = list(MATERIAL_STEEL = 3 SHEETS, MATERIAL_GOLD = 1.3 SHEETS, MATERIAL_COPPER = 1.3 SHEETS) //TODO
 	build_path = /obj/item/weapon/gun/projectile/pistol/magnum_pistol


### PR DESCRIPTION
It's used for nothing but grief due to its explosive properties, it's time to go.