### PR TITLE
Nerf material swords/bats/axes

### DIFF
--- a/code/game/objects/items/weapons/material/bats.dm
+++ b/code/game/objects/items/weapons/material/bats.dm
@@ -10,8 +10,8 @@
 	attack_verb = list("smashed", "beaten", "slammed", "smacked", "struck", "battered", "bonked")
 	sound_hit = 'sound/weapons/genhit3.ogg'
 	default_material = MATERIAL_MAPLE
-	force_divisor = 1.1           // 22 when wielded with weight 20 (steel)
-	unwielded_force_divisor = 0.7 // 15 when unwielded based on above.
+	force_divisor = 0.5          // 10 when wielded with weight 20 (steel)
+	unwielded_force_divisor = 0.3 // 6 when unwielded based on above.
 	attack_cooldown_modifier = 1
 	melee_accuracy_bonus = -10
 

--- a/code/game/objects/items/weapons/material/bats.dm
+++ b/code/game/objects/items/weapons/material/bats.dm
@@ -10,8 +10,8 @@
 	attack_verb = list("smashed", "beaten", "slammed", "smacked", "struck", "battered", "bonked")
 	sound_hit = 'sound/weapons/genhit3.ogg'
 	default_material = MATERIAL_MAPLE
-	force_divisor = 0.5          // 10 when wielded with weight 20 (steel)
-	unwielded_force_divisor = 0.3 // 6 when unwielded based on above.
+	force_divisor = 0.45          // 9 when wielded with weight 20 (steel)
+	unwielded_force_divisor = 0.35 // 7 when unwielded based on above.
 	attack_cooldown_modifier = 1
 	melee_accuracy_bonus = -10
 

--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -5,7 +5,7 @@
 	item_state = "claymore"
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_LARGE
-	force_divisor = 0.5 // 30 when wielded with hardnes 60 (steel)
+	force_divisor = 0.333 // 20 when wielded with hardnes 60 (steel)
 	thrown_force_divisor = 0.5 // 10 when thrown with weight 20 (steel)
 	sharpness = 1
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")

--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -5,7 +5,7 @@
 	item_state = "claymore"
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_LARGE
-	force_divisor = 0.333 // 20 when wielded with hardnes 60 (steel)
+	force_divisor = 0.25 // 20 when wielded with hardness 60 (steel)
 	thrown_force_divisor = 0.5 // 10 when thrown with weight 20 (steel)
 	sharpness = 1
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
@@ -16,7 +16,7 @@
 	mass = 3.6 
 /obj/item/weapon/material/sword/replica
 	sharpness = 0
-	force_divisor = 0.2
+	force_divisor = 0.15
 	thrown_force_divisor = 0.2
 	damtype = DAM_BLUNT
 	mass = 1
@@ -32,7 +32,7 @@
 
 /obj/item/weapon/material/sword/katana/replica
 	sharpness = 0
-	force_divisor = 0.2
+	force_divisor = 0.15
 	thrown_force_divisor = 0.2
 	damtype = DAM_BLUNT
 	mass = 1

--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -5,7 +5,7 @@
 	item_state = "claymore"
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_LARGE
-	force_divisor = 0.25 // 20 when wielded with hardness 60 (steel)
+	force_divisor = 0.25 // 15 when wielded with hardness 60 (steel)
 	thrown_force_divisor = 0.5 // 10 when thrown with weight 20 (steel)
 	sharpness = 1
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -79,8 +79,8 @@
 	name = "fire axe"
 	desc = "Truly, the weapon of a madman. Who would think to fight fire with an axe?"
 
-	force_divisor = 0.525
-	unwielded_force_divisor = 0.25
+	force_divisor = 0.27
+	unwielded_force_divisor = 0.15
 	sharpness = 2
 	attack_cooldown_modifier = 2
 	force_wielded = 15


### PR DESCRIPTION
Material swords and bats both managed to escape the weapons balancing wave unscathed, leaving all material swords with 30 damage, compared to their high tech cousin's 15 (one of which requiring approaching 10000 research to acquire, and the other... something like 300). Similarly, bats are capable of dealing up to a whopping 44 damage with the right materials used. This puts swords and heavy bats at around 15-18 damage each, keeping them relevant in comparison to actual researched weapons, while giving the research weapons some greater room to breathe as far as usability goes.

(For note, likely due to a bug, material weapons still attack twice as fast as energy weapons. Damage numbers will be re-evaluated if the bug finds itself being fixed.)

Edit: Fire axes got caught being overpowered too. Applied the nerfed bat to the axe.