### PR TITLE
[Recovery PR] Scrubber perf improvement

### DIFF
--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -36,6 +36,21 @@
 			if(g != GAS_OXYGEN && g != GAS_NITROGEN)
 				scrubbing_gas += g
 
+/obj/machinery/portable_atmospherics/powered/scrubber/turn_on()
+	. = ..()
+	START_PROCESSING(SSmachines, src)
+
+/obj/machinery/portable_atmospherics/powered/scrubber/turn_off()
+	. = ..()
+	STOP_PROCESSING(SSmachines, src)
+
+/obj/machinery/portable_atmospherics/powered/scrubber/proc/toggle()
+	on = !on
+	if(on)
+		START_PROCESSING(SSmachines, src)
+	else
+		STOP_PROCESSING(SSmachines, src)
+	update_icon()
 
 /obj/machinery/portable_atmospherics/powered/scrubber/emp_act(severity)
 	if(inoperable())
@@ -43,8 +58,7 @@
 		return
 
 	if(prob(50/severity))
-		on = !on
-		update_icon()
+		toggle()
 
 	..(severity)
 
@@ -65,6 +79,9 @@
 	return
 
 /obj/machinery/portable_atmospherics/powered/scrubber/Process()
+	//No point in running in nullspace!
+	if(isnull(loc) || QDELETED(src))
+		return PROCESS_KILL
 	..()
 
 	var/power_draw = -1
@@ -140,7 +157,7 @@
 
 /obj/machinery/portable_atmospherics/powered/scrubber/OnTopic(user, href_list)
 	if(href_list["power"])
-		on = !on
+		toggle()
 		. = TOPIC_REFRESH
 	if (href_list["remove_tank"])
 		if(holding)
@@ -202,6 +219,8 @@
 		queue_icon_update()
 
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/Process()
+	if(isnull(loc) || QDELETED(src))
+		return PROCESS_KILL
 	if(!ison() || inoperable())
 		update_use_power(POWER_USE_OFF)
 		last_flow_rate = 0


### PR DESCRIPTION
Make scrubbers remove themselves from the processing list when they're off. And back in when they're on. Should reduce the length of the processing list, and speed things up a bit in some cases.

* Scrubbers are pretty processing intensive and there are a ton of them. Removing the ones that are off from the processing queue would be a completely free net benefit performance wise.

<!-- 
!!IMPORTANT!!
Changes must be reviewed and approved by a developer before being merged.

If a developer has approved your PR, any other developer may immediately merge it, or the same developer may merge it after 24 hours.

A developer may not merge their own PR without the approval of two other developers.

Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
